### PR TITLE
feat(draft): persist draft mode selection to localStorage

### DIFF
--- a/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
@@ -136,6 +136,12 @@ interface DraftState {
 
 const DEFAULT_POSITIONS: DraftPositionFilter[] = ["QB", "RB", "WR", "TE"];
 const BEST_AVAILABLE_POSITIONS: DraftPositionFilter[] = ["QB", "RB", "WR", "TE"];
+const DRAFT_MODE_STORAGE_KEY = "draftAssistant.draftMode";
+const VALID_DRAFT_MODES: DraftMode[] = ["startup", "rookie", "redraft"];
+
+function isDraftMode(value: unknown): value is DraftMode {
+  return VALID_DRAFT_MODES.includes(value as DraftMode);
+}
 
 /** Compute how many picks until the user's turn (0 = user's pick now). */
 function calcPicksUntilMyTurn(currentPickNumber: number, userSlot: number, teams: number): number {
@@ -1067,8 +1073,6 @@ export const DraftStore = signalStore(
         `draftAssistant.sortSource.${leagueId}`;
       const positionsStorageKey = (leagueId: string): string =>
         `draftAssistant.positions.${leagueId}`;
-      const DRAFT_MODE_STORAGE_KEY = "draftAssistant.draftMode";
-
       const stopPolling = (): void => {
         if (pollHandle !== null) {
           clearInterval(pollHandle);
@@ -1799,10 +1803,9 @@ export const DraftStore = signalStore(
 
     return {
       onInit(): void {
-        const savedMode = storage.getRawItem("draftAssistant.draftMode");
-        const validModes: DraftMode[] = ["startup", "rookie", "redraft"];
-        if (validModes.includes(savedMode as DraftMode)) {
-          storeWithMethods.setDraftMode(savedMode as DraftMode);
+        const savedMode = storage.getRawItem(DRAFT_MODE_STORAGE_KEY);
+        if (isDraftMode(savedMode)) {
+          storeWithMethods.setDraftMode(savedMode);
         }
 
         effect(() => {

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
@@ -1067,6 +1067,7 @@ export const DraftStore = signalStore(
         `draftAssistant.sortSource.${leagueId}`;
       const positionsStorageKey = (leagueId: string): string =>
         `draftAssistant.positions.${leagueId}`;
+      const DRAFT_MODE_STORAGE_KEY = "draftAssistant.draftMode";
 
       const stopPolling = (): void => {
         if (pollHandle !== null) {
@@ -1701,6 +1702,7 @@ export const DraftStore = signalStore(
         },
         setDraftMode(draftMode: DraftMode): void {
           patchState(store, { draftMode });
+          storage.setRawItem(DRAFT_MODE_STORAGE_KEY, draftMode);
         },
         setTierSource(tierSource: TierSource): void {
           patchState(store, { tierSource });
@@ -1787,15 +1789,22 @@ export const DraftStore = signalStore(
       };
     },
   ),
-  withHooks((store, appStore = inject(AppStore)) => {
+  withHooks((store, appStore = inject(AppStore), storage = inject(StorageService)) => {
     let previousLeagueId: string | null = null;
     const storeWithMethods = store as typeof store & {
       loadForSelectedLeague: () => Promise<void>;
       stopPolling: () => void;
+      setDraftMode: (mode: DraftMode) => void;
     };
 
     return {
       onInit(): void {
+        const savedMode = storage.getRawItem("draftAssistant.draftMode");
+        const validModes: DraftMode[] = ["startup", "rookie", "redraft"];
+        if (validModes.includes(savedMode as DraftMode)) {
+          storeWithMethods.setDraftMode(savedMode as DraftMode);
+        }
+
         effect(() => {
           const leagueId = appStore.selectedLeague()?.league_id ?? null;
           if (leagueId === previousLeagueId) {


### PR DESCRIPTION
## Summary

- The "Draft Mode" dropdown (Startup / Rookie / Redraft) was already in the UI but the selection was lost on every page refresh
- Save the selected mode to `localStorage` under `draftAssistant.draftMode` whenever `setDraftMode` is called
- Restore it in `onInit` before the league-load effect fires, so WCS source weights and NeedMultiplier params are applied correctly from the very first computation

## Test plan

- [ ] Select "Rookie Draft" mode in the draft controls, refresh the page — mode should still be "Rookie Draft"
- [ ] Verify WCS scores visibly shift when switching between Startup and Redraft modes on the same draft
- [ ] Verify a fresh session (no stored key) defaults to "Startup / Dynasty"

https://claude.ai/code/session_01TnXL41fX1vecQxzXCaaij4

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnXL41fX1vecQxzXCaaij4)_