### PR TITLE
fix(draft): wire flockRookie as separate consensus source

### DIFF
--- a/apps/draft-assistant/frontend/src/app/core/models/index.ts
+++ b/apps/draft-assistant/frontend/src/app/core/models/index.ts
@@ -92,6 +92,10 @@ export interface DraftPlayerRow {
   flockAveragePositionalTier: number | null;
   flockAveragePositionalRank: number | null;
   averageRank: number | null;
+  /** Flock prospect/rookie-only rank (from the separate rookies asset). Null for veterans. */
+  flockRookieRank: number | null;
+  /** Flock prospect/rookie-only average tier. Null for veterans. */
+  flockRookieTier: number | null;
   sleeperRank: number;
   /** Sum of KTC overall tier + Flock average tier (lower = better). */
   combinedTier: number | null;

--- a/apps/draft-assistant/frontend/src/app/core/services/player-normalization.service.ts
+++ b/apps/draft-assistant/frontend/src/app/core/services/player-normalization.service.ts
@@ -51,6 +51,7 @@ export class PlayerNormalizationService {
     fcLookup: Map<string, FantasyCalcPlayer> = new Map(),
     fcSleeperLookup: Map<string, FantasyCalcPlayer> = new Map(),
     ffcLookup: Map<string, FfcAdpPlayer> = new Map(),
+    flockRookieLookup: Map<string, FlockPlayer> = new Map(),
   ): Omit<DraftPlayerRow, "sleeperRank" | "adpDelta"> {
     const firstName = source.first_name ?? "";
     const lastName = source.last_name ?? "";
@@ -59,6 +60,7 @@ export class PlayerNormalizationService {
 
     const ktcPlayer = ktcLookup.get(this.ktcService.normalizeName(fullName));
     const flockPlayer = flockLookup.get(this.flockService.normalizeName(fullName));
+    const flockRookiePlayer = flockRookieLookup.get(this.flockService.normalizeName(fullName));
     const fpAdpPlayer = fpAdpLookup.get(this.fpAdpService.normalizeName(fullName));
     // FantasyCalc ships sleeperId for most active players; prefer it over name match.
     const fcPlayer =
@@ -115,6 +117,8 @@ export class PlayerNormalizationService {
       flockAveragePositionalTier: flockPositionalTier,
       flockAveragePositionalRank: flockPositionalRank,
       averageRank: flockAverageRank,
+      flockRookieRank: flockRookiePlayer?.averageRank ?? null,
+      flockRookieTier: flockRookiePlayer?.averageTier ?? null,
       combinedTier,
       combinedPositionalTier,
       adpRank,
@@ -147,6 +151,7 @@ export class PlayerNormalizationService {
     fcLookup: Map<string, FantasyCalcPlayer> = new Map(),
     fcSleeperLookup: Map<string, FantasyCalcPlayer> = new Map(),
     ffcLookup: Map<string, FfcAdpPlayer> = new Map(),
+    flockRookieLookup: Map<string, FlockPlayer> = new Map(),
   ): DraftPlayerRow[] {
     const positionSet = new Set<string>(positions);
 
@@ -163,6 +168,7 @@ export class PlayerNormalizationService {
           fcLookup,
           fcSleeperLookup,
           ffcLookup,
+          flockRookieLookup,
         ),
       )
       .filter((row) => row.fullName.length > 0)

--- a/apps/draft-assistant/frontend/src/app/core/services/player-normalization.service.ts
+++ b/apps/draft-assistant/frontend/src/app/core/services/player-normalization.service.ts
@@ -59,8 +59,9 @@ export class PlayerNormalizationService {
     const position = (source.position ?? "") as DraftPlayerRow["position"];
 
     const ktcPlayer = ktcLookup.get(this.ktcService.normalizeName(fullName));
-    const flockPlayer = flockLookup.get(this.flockService.normalizeName(fullName));
-    const flockRookiePlayer = flockRookieLookup.get(this.flockService.normalizeName(fullName));
+    const flockKey = this.flockService.normalizeName(fullName);
+    const flockPlayer = flockLookup.get(flockKey);
+    const flockRookiePlayer = flockRookieLookup.get(flockKey);
     const fpAdpPlayer = fpAdpLookup.get(this.fpAdpService.normalizeName(fullName));
     // FantasyCalc ships sleeperId for most active players; prefer it over name match.
     const fcPlayer =

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-ranking.util.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-ranking.util.spec.ts
@@ -54,12 +54,32 @@ describe("draft-ranking.util", () => {
       expect(resolveDraftTier(row, "flock")).toBe(4);
     });
 
+    it("uses rookie flock tier when veteran flock tier is null", () => {
+      const row = buildRow({
+        positionalTier: 4,
+        flockAveragePositionalTier: null,
+        flockAverageTier: null,
+        flockRookieTier: 1,
+      });
+      expect(resolveDraftTier(row, "flock")).toBe(1);
+    });
+
+    it("prefers veteran flock tier over rookie flock tier when both are present", () => {
+      const row = buildRow({
+        flockAveragePositionalTier: null,
+        flockAverageTier: 3,
+        flockRookieTier: 1,
+      });
+      expect(resolveDraftTier(row, "flock")).toBe(3);
+    });
+
     it("returns MAX_SAFE_INTEGER when no tier data is available", () => {
       const row = buildRow({
         positionalTier: null,
         overallTier: null,
         flockAveragePositionalTier: null,
         flockAverageTier: null,
+        flockRookieTier: null,
       });
       expect(resolveDraftTier(row, "flock")).toBe(Number.MAX_SAFE_INTEGER);
     });
@@ -81,8 +101,18 @@ describe("draft-ranking.util", () => {
       expect(resolveDraftValue(row, "averageRank")).toBe(-12);
     });
 
-    it("falls back to ktcValue when averageRank is unavailable", () => {
-      const row = buildRow({ averageRank: null, ktcValue: 2500 });
+    it("falls back to rookie rank when veteran averageRank is null", () => {
+      const row = buildRow({ averageRank: null, flockRookieRank: 5, ktcValue: 2500 });
+      expect(resolveDraftValue(row, "averageRank")).toBe(-5);
+    });
+
+    it("prefers veteran averageRank over rookie rank when both are present", () => {
+      const row = buildRow({ averageRank: 12, flockRookieRank: 5, ktcValue: 2500 });
+      expect(resolveDraftValue(row, "averageRank")).toBe(-12);
+    });
+
+    it("falls back to ktcValue when both averageRank and rookie rank are unavailable", () => {
+      const row = buildRow({ averageRank: null, flockRookieRank: null, ktcValue: 2500 });
       expect(resolveDraftValue(row, "averageRank")).toBe(2500);
     });
   });

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-ranking.util.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-ranking.util.spec.ts
@@ -20,6 +20,8 @@ function buildRow(overrides: Partial<DraftPlayerRow> = {}): DraftPlayerRow {
     flockAveragePositionalTier: 2,
     flockAveragePositionalRank: 3,
     averageRank: 12,
+    flockRookieRank: null,
+    flockRookieTier: null,
     sleeperRank: 20,
     combinedTier: 3,
     combinedPositionalTier: 2,

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-ranking.util.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-ranking.util.ts
@@ -5,7 +5,9 @@ export type DraftValueSource = "ktcValue" | "averageRank";
 
 export function resolveDraftTier(row: DraftPlayerRow, tierSrc: TierSource): number {
   const ktcTier = row.positionalTier ?? row.overallTier ?? null;
-  const flockTier = row.flockAveragePositionalTier ?? row.flockAverageTier ?? null;
+  // Fall back to rookie Flock tier for prospects not present in veteran Flock rankings.
+  const flockTier =
+    row.flockAveragePositionalTier ?? row.flockAverageTier ?? row.flockRookieTier ?? null;
 
   if (tierSrc === "flock" && flockTier === null) {
     return ktcTier ?? Number.MAX_SAFE_INTEGER;
@@ -18,7 +20,8 @@ export function resolveDraftValue(row: DraftPlayerRow, valueSrc: DraftValueSourc
   if (valueSrc === "ktcValue") return row.ktcValue ?? 0;
 
   // averageRank is lower-is-better; negate so higher return value = better player.
-  // Fall back to ktcValue when averageRank is unavailable.
+  // Fall back to rookie rank for prospects not in veteran Flock, then ktcValue.
   if (row.averageRank !== null) return -row.averageRank;
+  if (row.flockRookieRank !== null) return -row.flockRookieRank;
   return row.ktcValue ?? 0;
 }

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-sort.util.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-sort.util.spec.ts
@@ -24,6 +24,8 @@ function buildRow(overrides: Partial<DraftPlayerRow> = {}): DraftPlayerRow {
     flockAveragePositionalTier: 2,
     flockAveragePositionalRank: 3,
     averageRank: 12,
+    flockRookieRank: null,
+    flockRookieTier: null,
     sleeperRank: 20,
     combinedTier: 3,
     combinedPositionalTier: 2,

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
@@ -304,6 +304,8 @@ export const DraftStore = signalStore(
             const sources: ConsensusInput["sources"] = [];
             if (row.ktcRank !== null) sources.push({ source: "ktc", rank: row.ktcRank });
             if (row.averageRank !== null) sources.push({ source: "flock", rank: row.averageRank });
+            if (row.flockRookieRank !== null)
+              sources.push({ source: "flockRookie", rank: row.flockRookieRank });
             if (row.fantasyCalcValue !== null)
               sources.push({ source: "fantasycalc", value: row.fantasyCalcValue });
             if (row.fpAdpRank !== null) sources.push({ source: "fpAdp", rank: row.fpAdpRank });
@@ -1137,6 +1139,7 @@ export const DraftStore = signalStore(
         fcLookup: Map<string, FantasyCalcPlayer> = new Map(),
         fcSleeperLookup: Map<string, FantasyCalcPlayer> = new Map(),
         ffcLookup: Map<string, FfcAdpPlayer> = new Map(),
+        flockRookieLookup: Map<string, FlockPlayer> = new Map(),
       ): DraftPlayerRow[] =>
         playerNorm.buildPlayerRows(
           playersById,
@@ -1148,6 +1151,7 @@ export const DraftStore = signalStore(
           fcLookup,
           fcSleeperLookup,
           ffcLookup,
+          flockRookieLookup,
         );
 
       // Pick the FantasyCalc + FFC variants that match the active league format.
@@ -1309,12 +1313,8 @@ export const DraftStore = signalStore(
         );
 
         const ktcLookup = ktc.buildNameLookup(ktcPlayers);
-        const flockLookup = isRookieDraft
-          ? new Map([
-              ...flock.buildNameLookup(flockRookies),
-              ...flock.buildNameLookup(flockPlayers),
-            ])
-          : flock.buildNameLookup(flockPlayers);
+        const flockLookup = flock.buildNameLookup(flockPlayers);
+        const flockRookieLookup = flock.buildNameLookup(flockRookies);
         const fpAdpLookup = fpAdp.buildNameLookup(fpAdpPlayers);
         const fcLookup = fc.buildNameLookup(fcPlayers);
         const fcSleeperLookup = fc.buildSleeperIdLookup(fcPlayers);
@@ -1328,6 +1328,7 @@ export const DraftStore = signalStore(
           fcLookup,
           fcSleeperLookup,
           ffcLookup,
+          flockRookieLookup,
         );
 
         let rosterDisplayNames: Record<string, string> = {};
@@ -1538,12 +1539,8 @@ export const DraftStore = signalStore(
           }
 
           const isRookieDraft = selectedDraft ? isSleeperRookieDraft(selectedDraft) : false;
-          const flockLookup = isRookieDraft
-            ? new Map([
-                ...flock.buildNameLookup(flockRookies),
-                ...flock.buildNameLookup(flockPlayers),
-              ])
-            : flock.buildNameLookup(flockPlayers);
+          const flockLookup = flock.buildNameLookup(flockPlayers);
+          const flockRookieLookup = flock.buildNameLookup(flockRookies);
           const fpAdpLookup = fpAdp.buildNameLookup(fpAdpPlayers);
 
           // Swap to rookie-format FC/FFC data if we discovered this is a rookie draft.
@@ -1565,6 +1562,7 @@ export const DraftStore = signalStore(
             fcLookup,
             fcSleeperLookup,
             ffcLookup,
+            flockRookieLookup,
           );
 
           const starredPlayerIds = (() => {


### PR DESCRIPTION
## Problem

In rookie mode `SOURCE_WEIGHTS.rookie` sets `flock: 0.0, flockRookie: 0.45`, but all Flock observations were always pushed as `source: "flock"`. This meant:
- Flock data was **zero-weighted** in rookie mode (because `flock: 0.0`)
- The `flockRookie: 0.45` weight was **never applied** (no observation ever used that key)
- Prospects like Jeremiyah Love (Flock rookie rank #1) fell to Tier 4 because their veteran Flock tier was null, falling back to KTC

Additionally, the rookie Flock lookup was only merged when the Sleeper draft type was a rookie draft — so setting the UI mode selector to "Rookie" had no effect on which Flock data was used.

## Fix

- Add `flockRookieRank` and `flockRookieTier` fields to `DraftPlayerRow`
- Always build a separate `flockRookieLookup` from `flockRookies` (not conditional on Sleeper draft type)
- Populate the new fields during player normalization
- Push a `{ source: "flockRookie" }` ConsensusInput observation so the 0.45 mode weight applies correctly
- `resolveDraftTier` and `resolveDraftValue` now fall back to rookie Flock data for prospects absent from veteran Flock rankings

## Test plan

- [ ] Set draft mode to "Rookie Draft" and tier source to "Flock" — Jeremiyah Love should appear in Tier 1
- [ ] Verify WCS scores shift meaningfully when switching between Startup and Rookie mode (Flock rookie weight 0.0 → 0.45)
- [ ] Verify veterans with no rookie Flock entry are unaffected (their `flockRookieRank` is null)
- [ ] Verify Startup mode is unchanged (flock: 0.3, flockRookie: 0.05)

https://claude.ai/code/session_01TnXL41fX1vecQxzXCaaij4

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnXL41fX1vecQxzXCaaij4)_