### PR TITLE
fix(draft): tier dividers respect selected tier source

### DIFF
--- a/apps/draft-assistant/frontend/src/app/core/services/player-normalization.service.ts
+++ b/apps/draft-assistant/frontend/src/app/core/services/player-normalization.service.ts
@@ -78,18 +78,19 @@ export class PlayerNormalizationService {
     const fpAdpRank = fpAdpPlayer?.adpRank ?? null;
 
     // SRS §3.1: combinedTier = sum of all available source tiers (lower = better).
-    // When only one source has data the missing source contributes 0 to the sum, so
-    // single-source players will sort ahead of dual-source players with the same
-    // individual tier.  This is intentional: a player recognised by at least one
-    // high-quality source is still considered preferable to an unranked player.
+    // For prospects absent from veteran Flock rankings, fall back to rookie Flock tier.
+    const flockRookieTierVal = flockRookiePlayer?.averageTier ?? null;
+    const effectiveFlockTier = flockTier ?? flockRookieTierVal;
     const combinedTier =
-      ktcOverallTier !== null || flockTier !== null
-        ? (ktcOverallTier ?? 0) + (flockTier ?? 0)
+      ktcOverallTier !== null || effectiveFlockTier !== null
+        ? (ktcOverallTier ?? 0) + (effectiveFlockTier ?? 0)
         : null;
 
+    const flockRookiePositionalTierVal = flockRookiePlayer?.averagePositionalTier ?? null;
+    const effectiveFlockPositionalTier = flockPositionalTier ?? flockRookiePositionalTierVal;
     const combinedPositionalTier =
-      ktcPositionalTier !== null || flockPositionalTier !== null
-        ? (ktcPositionalTier ?? 0) + (flockPositionalTier ?? 0)
+      ktcPositionalTier !== null || effectiveFlockPositionalTier !== null
+        ? (ktcPositionalTier ?? 0) + (effectiveFlockPositionalTier ?? 0)
         : null;
 
     // ADP: use flockAverageRank as proxy for Sleeper ADP (REQ-DS-05 / REQ-ADP-01).

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-player-list/draft-player-list.component.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-player-list/draft-player-list.component.ts
@@ -66,7 +66,7 @@ export class DraftPlayerListComponent {
   });
   protected readonly userNextPickNumber = computed(() => this.store.userNextPickNumber());
 
-  protected rowCombinedTier(row: DraftPlayerRow): number | null {
+  protected rowResolvedTier(row: DraftPlayerRow): number | null {
     const resolved = resolveDraftTier(row, this.store.tierSource());
     return resolved === Number.MAX_SAFE_INTEGER ? null : resolved;
   }
@@ -88,7 +88,7 @@ export class DraftPlayerListComponent {
 
   protected tierColorClass(row: DraftPlayerDisplayRow): string {
     if (row.isDrafted) return "";
-    return getTierColorClass(this.rowCombinedTier(row));
+    return getTierColorClass(this.rowResolvedTier(row));
   }
 
   protected sortSourceRankLabel(): string {
@@ -105,10 +105,10 @@ export class DraftPlayerListComponent {
   ): boolean {
     if (undraftedIndex === 0) return true;
     const currentTier = undraftedRows[undraftedIndex]
-      ? this.rowCombinedTier(undraftedRows[undraftedIndex])
+      ? this.rowResolvedTier(undraftedRows[undraftedIndex])
       : null;
     const previousTier = undraftedRows[undraftedIndex - 1]
-      ? this.rowCombinedTier(undraftedRows[undraftedIndex - 1])
+      ? this.rowResolvedTier(undraftedRows[undraftedIndex - 1])
       : null;
     return currentTier !== previousTier;
   }
@@ -138,7 +138,7 @@ export class DraftPlayerListComponent {
   }
 
   protected tierDividerLabel(row: DraftPlayerRow): string {
-    const tier = this.rowCombinedTier(row);
+    const tier = this.rowResolvedTier(row);
     return tier === null ? "Un-tiered" : `Tier ${tier}`;
   }
 

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-player-list/draft-player-list.component.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-player-list/draft-player-list.component.ts
@@ -14,6 +14,7 @@ import { DraftPlayerRow, SleeperPlayerStats } from "../../../core/models";
 import { DraftPlayerDisplayRow, DraftStore, rankForSortSource } from "../draft.store";
 import { sortSourceRankLabel, sortSourceShortLabel } from "../draft-display.util";
 import { getTierColorClass } from "../../../shared/pipes/tier-color.pipe";
+import { resolveDraftTier } from "../draft-ranking.util";
 import { SleeperStatsService } from "../../../core/adapters/sleeper/sleeper-stats.service";
 import { AppStore } from "../../../core/state/app.store";
 import { PlayerCardComponent } from "../../../shared/components/player-card";
@@ -66,7 +67,8 @@ export class DraftPlayerListComponent {
   protected readonly userNextPickNumber = computed(() => this.store.userNextPickNumber());
 
   protected rowCombinedTier(row: DraftPlayerRow): number | null {
-    return row.combinedTier;
+    const resolved = resolveDraftTier(row, this.store.tierSource());
+    return resolved === Number.MAX_SAFE_INTEGER ? null : resolved;
   }
 
   protected rowRank(row: DraftPlayerRow): number | null {
@@ -85,7 +87,8 @@ export class DraftPlayerListComponent {
   }
 
   protected tierColorClass(row: DraftPlayerDisplayRow): string {
-    return row.isDrafted ? "" : getTierColorClass(row.combinedTier);
+    if (row.isDrafted) return "";
+    return getTierColorClass(this.rowCombinedTier(row));
   }
 
   protected sortSourceRankLabel(): string {


### PR DESCRIPTION
## Problem

Tier dividers in the player list always read `row.combinedTier` (KTC overall tier + veteran Flock tier summed), regardless of the selected tier source. This caused two visible bugs:

1. With tier source set to **Flock**, Jeremiyah Love showed as **Tier 3** (his KTC tier) instead of **Tier 1** — his `averageTier` in the Flock rookie data is `1` (the only S-tier on FlockFantasy.com), but since he has no veteran Flock entry `combinedTier` collapsed to KTC-only
2. `combinedTier` itself didn't include rookie Flock data, so "average" tier source also ignored prospects

## Fix

- `rowCombinedTier` in `DraftPlayerListComponent` now calls `resolveDraftTier(row, store.tierSource())` — Flock source uses Flock tiers, KTC uses KTC tiers, average blends both
- Card border color (`tierColorClass`) follows the same resolved tier
- `combinedTier` in `PlayerNormalizationService` uses rookie Flock tier as fallback for the Flock component, so "average" tier source also reflects rookie prospect data

## Test plan

- [ ] Set tier source → Flock, sort → Flock Rank, mode → Rookie Draft: Jeremiyah Love should appear under **Tier 1**, Carnell Tate / Makai Lemon under Tier 2, matching FlockFantasy.com
- [ ] Switch tier source → KTC: tier dividers should revert to KTC-based groupings
- [ ] Switch tier source → Average: tier dividers should blend both sources

https://claude.ai/code/session_01TnXL41fX1vecQxzXCaaij4

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnXL41fX1vecQxzXCaaij4)_