### PR TITLE
feat(draft): explanation templates #12, #17, #21 + injuryStatus field

### DIFF
--- a/apps/draft-assistant/frontend/src/app/core/adapters/sleeper/sleeper.service.ts
+++ b/apps/draft-assistant/frontend/src/app/core/adapters/sleeper/sleeper.service.ts
@@ -52,4 +52,13 @@ export class SleeperService {
   getDraftPicks(draftId: string): Observable<SleeperDraftPick[]> {
     return this.http.get<SleeperDraftPick[]>(`${BASE}/draft/${draftId}/picks`);
   }
+
+  getTrendingPlayers(
+    type: "add" | "drop" = "add",
+    limit = 100,
+  ): Observable<{ player_id: string; count: number }[]> {
+    return this.http.get<{ player_id: string; count: number }[]>(
+      `${BASE}/players/nfl/trending/${type}?limit=${limit}`,
+    );
+  }
 }

--- a/apps/draft-assistant/frontend/src/app/core/models/index.ts
+++ b/apps/draft-assistant/frontend/src/app/core/models/index.ts
@@ -147,6 +147,8 @@ export interface DraftPlayerRow {
   tierCliffScore: number | null;
   /** Final Weighted Composite Score (Phase 1 simplified form); higher = better. */
   weightedCompositeScore: number | null;
+  /** Injury designation from Sleeper catalog (e.g. "Questionable", "Out", "IR"). Null when healthy. */
+  injuryStatus: string | null;
 }
 
 export interface DraftRecommendation {

--- a/apps/draft-assistant/frontend/src/app/core/services/player-normalization.service.ts
+++ b/apps/draft-assistant/frontend/src/app/core/services/player-normalization.service.ts
@@ -135,6 +135,7 @@ export class PlayerNormalizationService {
       pAvailAtNext: null,
       tierCliffScore: null,
       weightedCompositeScore: null,
+      injuryStatus: source.injury_status ?? null,
     };
   }
 

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-ranking.util.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-ranking.util.spec.ts
@@ -10,6 +10,7 @@ function buildRow(overrides: Partial<DraftPlayerRow> = {}): DraftPlayerRow {
     position: "QB",
     team: "KC",
     age: 25,
+    yearsExp: null,
     rookie: false,
     ktcValue: 1000,
     ktcRank: 10,
@@ -38,6 +39,7 @@ function buildRow(overrides: Partial<DraftPlayerRow> = {}): DraftPlayerRow {
     pAvailAtNext: null,
     tierCliffScore: null,
     weightedCompositeScore: null,
+    injuryStatus: null,
     ...overrides,
   };
 }

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-sort.util.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-sort.util.spec.ts
@@ -14,6 +14,7 @@ function buildRow(overrides: Partial<DraftPlayerRow> = {}): DraftPlayerRow {
     position: "QB",
     team: "KC",
     age: 25,
+    yearsExp: null,
     rookie: false,
     ktcValue: 1000,
     ktcRank: 10,
@@ -42,6 +43,7 @@ function buildRow(overrides: Partial<DraftPlayerRow> = {}): DraftPlayerRow {
     pAvailAtNext: null,
     tierCliffScore: null,
     weightedCompositeScore: null,
+    injuryStatus: null,
     ...overrides,
   };
 }

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
@@ -8,7 +8,8 @@ import {
   withMethods,
   withState,
 } from "@ngrx/signals";
-import { forkJoin, firstValueFrom } from "rxjs";
+import { forkJoin, firstValueFrom, of } from "rxjs";
+import { catchError } from "rxjs/operators";
 import { KtcRatingService } from "../../core/adapters/ktc/ktc-rating.service";
 import { isSleeperRookieDraft } from "../../core/adapters/sleeper/sleeper-draft.util";
 import { SleeperService } from "../../core/adapters/sleeper/sleeper.service";
@@ -293,10 +294,25 @@ export const DraftStore = signalStore(
       survival = inject(SurvivalService),
       appStore = inject(AppStore),
       nflverse = inject(NflverseService),
+      sleeperService = inject(SleeperService),
     ) => {
       // Nflverse data signals — load once, shareReplay(1) inside the service.
       const playerStatsMap = toSignal(nflverse.playerStats$, {
         initialValue: new Map(),
+      });
+
+      // Sleeper trending adds — top 100 most-added players in last 24 h.
+      // catchError so a Sleeper outage never crashes the WCS pipeline.
+      const trendingRaw = toSignal(
+        sleeperService.getTrendingPlayers("add", 100).pipe(catchError(() => of([]))),
+        { initialValue: [] as { player_id: string; count: number }[] },
+      );
+      const trendingTopTenMap = computed((): Map<string, number> => {
+        const out = new Map<string, number>();
+        for (const { player_id, count } of trendingRaw().slice(0, 10)) {
+          out.set(player_id, count);
+        }
+        return out;
       });
       const pfrStatsMap = toSignal(nflverse.pfrAdvStats$, { initialValue: new Map() });
       const ngsStatsMap = toSignal(nflverse.ngsStats$, { initialValue: new Map() });
@@ -557,6 +573,23 @@ export const DraftStore = signalStore(
           }
         }
 
+        // #12 StackSynergy — map each NFL team to the QB name on the user's roster.
+        const rowByPlayerId = new Map(store.rows().map((r) => [r.playerId, r]));
+        const userQbByTeam = new Map<string, string>();
+        const userRosterId = store.userRosterId();
+        for (const pid of store.existingRosterPlayerIds()) {
+          const r = rowByPlayerId.get(pid);
+          if (r?.position === "QB" && r.team) userQbByTeam.set(r.team, r.fullName);
+        }
+        if (userRosterId !== null) {
+          for (const pick of store.picks()) {
+            if (pick.roster_id !== userRosterId || !pick.player_id) continue;
+            const r = rowByPlayerId.get(pick.player_id);
+            if (r?.position === "QB" && r.team) userQbByTeam.set(r.team, r.fullName);
+          }
+        }
+        const trendingMap = trendingTopTenMap();
+
         const out = new Map<string, string>();
         for (const row of store.rows()) {
           const base = baseMap.get(row.playerId);
@@ -564,6 +597,8 @@ export const DraftStore = signalStore(
           const tierInfo = cliffMap.get(row.playerId);
           const effScore = effMap.get(row.playerId) ?? null;
           const playerStats = playerStatsMap().get(row.playerId);
+          const stackSynergyQbName =
+            row.position !== "QB" && row.team ? (userQbByTeam.get(row.team) ?? null) : null;
           const explanation = generateExplanation({
             baseValue: base.baseValue,
             baseValueDivergence: base.divergence,
@@ -593,6 +628,9 @@ export const DraftStore = signalStore(
                   }
                 : null,
             vnp: vnpMap.get(row.playerId) ?? null,
+            stackSynergyQbName,
+            trendingAdds: trendingMap.get(row.playerId) ?? null,
+            injuryStatus: row.injuryStatus,
           });
           if (explanation) out.set(row.playerId, explanation);
         }

--- a/apps/draft-assistant/frontend/src/app/features/draft/score-explanation.util.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/score-explanation.util.spec.ts
@@ -101,4 +101,80 @@ describe("score-explanation.util", () => {
     const withoutValue = generateExplanation(buildSignals({ baseValueDivergence: 1.0 }));
     expect(withoutValue).not.toContain("Splits rankings");
   });
+
+  describe("template #12 — QB stack synergy", () => {
+    it("fires for a WR whose team QB is on the user roster", () => {
+      const out = generateExplanation(
+        buildSignals({ position: "WR", stackSynergyQbName: "P. Mahomes" }),
+      );
+      expect(out).toContain("QB stack with P. Mahomes");
+    });
+
+    it("does not fire for a QB (self-stack guard)", () => {
+      const out = generateExplanation(
+        buildSignals({ position: "QB", stackSynergyQbName: "P. Mahomes" }),
+      );
+      expect(out).not.toContain("QB stack");
+    });
+
+    it("does not fire when stackSynergyQbName is null", () => {
+      const out = generateExplanation(buildSignals({ stackSynergyQbName: null }));
+      expect(out).not.toContain("QB stack");
+    });
+  });
+
+  describe("template #17 — Sleeper trending adds", () => {
+    it("fires when trendingAdds is non-null", () => {
+      const out = generateExplanation(buildSignals({ trendingAdds: 4500 }));
+      expect(out).toContain("Trending");
+      expect(out).toContain("4,500");
+    });
+
+    it("does not fire when trendingAdds is null", () => {
+      const out = generateExplanation(buildSignals({ trendingAdds: null }));
+      expect(out).not.toContain("Trending");
+    });
+  });
+
+  describe("template #21 — injury designation", () => {
+    it("fires with magnitude 20 for Out status", () => {
+      const out = generateExplanation(buildSignals({ injuryStatus: "Out" }));
+      expect(out).toContain("🏥 Out");
+    });
+
+    it("fires with magnitude 20 for IR status", () => {
+      const out = generateExplanation(buildSignals({ injuryStatus: "IR" }));
+      expect(out).toContain("🏥 IR");
+    });
+
+    it("fires with magnitude 15 for Doubtful status", () => {
+      const out = generateExplanation(buildSignals({ injuryStatus: "Doubtful" }));
+      expect(out).toContain("🏥 Doubtful");
+    });
+
+    it("fires with magnitude 10 for Questionable status", () => {
+      const out = generateExplanation(buildSignals({ injuryStatus: "Questionable" }));
+      expect(out).toContain("🏥 Questionable");
+    });
+
+    it("does not fire when injuryStatus is null", () => {
+      const out = generateExplanation(buildSignals({ injuryStatus: null }));
+      expect(out).not.toContain("🏥");
+    });
+
+    it("injury (Out) takes precedence over lower-magnitude clauses", () => {
+      // Out magnitude=20 should beat position-run magnitude ~20 and young-age magnitude=8
+      const out = generateExplanation(
+        buildSignals({
+          injuryStatus: "Out",
+          position: "RB",
+          age: 22,
+          positionRunCount: 4,
+          positionRunWindow: 6,
+        }),
+        { maxClauses: 1 },
+      );
+      expect(out).toContain("🏥 Out");
+    });
+  });
 });

--- a/apps/draft-assistant/frontend/src/app/features/draft/score-explanation.util.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/score-explanation.util.ts
@@ -64,6 +64,12 @@ export interface ExplanationSignals {
   } | null;
   /** VNP score (Value over Next Pick). */
   vnp?: number | null;
+  /** QB name on the user's roster that shares this player's team (pass-catchers only). */
+  stackSynergyQbName?: string | null;
+  /** Number of Sleeper adds for this player in the last 24 h (null = not in top-100). */
+  trendingAdds?: number | null;
+  /** Active Sleeper injury designation string (e.g. "Questionable", "Out", "IR"). */
+  injuryStatus?: string | null;
 }
 
 export interface ExplanationOptions {
@@ -271,6 +277,37 @@ export function generateExplanation(
     clauses.push({
       magnitude: signals.baseValueDivergence * 5,
       text: `🎭 Splits rankings: sources disagree, market is undervaluing`,
+    });
+  }
+
+  // #12 QB stack synergy
+  if (signals.stackSynergyQbName && signals.position !== "QB") {
+    clauses.push({
+      magnitude: 11,
+      text: `🔗 QB stack with ${signals.stackSynergyQbName} (on your roster)`,
+    });
+  }
+
+  // #17 Sleeper trending adds
+  if (signals.trendingAdds !== null && signals.trendingAdds !== undefined) {
+    clauses.push({
+      magnitude: 14,
+      text: `🔥 Trending: +${signals.trendingAdds.toLocaleString()} adds in last 24h`,
+    });
+  }
+
+  // #21 Injury designation
+  if (signals.injuryStatus) {
+    const statusLower = signals.injuryStatus.toLowerCase();
+    const magnitude =
+      statusLower === "out" || statusLower === "ir" || statusLower === "pup"
+        ? 20
+        : statusLower === "doubtful"
+          ? 15
+          : 10;
+    clauses.push({
+      magnitude,
+      text: `🏥 ${signals.injuryStatus}`,
     });
   }
 


### PR DESCRIPTION
## Summary

- **Template #12 — QB stack synergy**: surfaces `🔗 QB stack with {name} (on your roster)` when a WR/RB/TE's team QB has already been drafted by the user
- **Template #17 — Sleeper trending**: surfaces `🔥 Trending: +{N} adds in last 24h` for any player in Sleeper's live top-10 most-added list (fetched once via new `SleeperService.getTrendingPlayers()`)
- **Template #21 — Injury designation**: surfaces `🏥 {status}` for any player with an active Sleeper injury status; magnitude scales by severity so Out/IR always surfaces first in the 3-clause limit
- **`injuryStatus` field**: added to `DraftPlayerRow` and populated from `SleeperCatalogPlayer.injury_status` in `PlayerNormalizationService`

## Test plan

- [ ] Load a dynasty draft where you have a QB already drafted — a same-team WR/TE should show the stack clause in their explanation card
- [ ] Check a player with an active injury designation in Sleeper — they should show `🏥 Out` (or equivalent) as the top explanation clause
- [ ] Verify trending clause appears for a player currently in Sleeper's top-10 adds (may require a live draft session during in-season)
- [ ] `ng test` — existing specs green, no new type errors

https://claude.ai/code/session_01TnXL41fX1vecQxzXCaaij4

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnXL41fX1vecQxzXCaaij4)_