### PR TITLE
fix(player-card): restore mobile-friendly layout for narrow viewports

### DIFF
--- a/apps/draft-assistant/frontend/src/app/shared/components/player-card/player-card.component.scss
+++ b/apps/draft-assistant/frontend/src/app/shared/components/player-card/player-card.component.scss
@@ -44,6 +44,7 @@
 .card-inner {
   flex: 1;
   min-width: 0;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
 }
@@ -675,8 +676,18 @@ html.dark {
 }
 
 // ── Responsive ────────────────────────────────────────────────────────────────
-@media (max-width: 480px) {
-  .pills-row {
+@media (max-width: 640px) {
+  // Collapse header to 3 columns: hide WCS badge to free space for player name.
+  .card-header {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+
+  .card-badges {
+    display: none;
+  }
+
+  .pills-row,
+  .player-explanation {
     display: none;
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #69. The mobile fix commit was pushed after #69 was merged and landed on a stale proxy endpoint — it never reached GitHub. This PR carries that single fix.

**What broke:** When the PR was merged, `player-card.component.scss` had a responsive block that only hid `pills-row` at `≤480px` — it was missing the old `card-header` 3-column override that existed before the refactor. Without it, all viewport sizes kept the 4-column header (avatar · meta · WCS badge · star), squeezing the player name and causing horizontal overflow on narrow screens.

**Changes (one commit, one file):**
- `card-inner` gets `overflow: hidden` to prevent child content escaping flex bounds
- Breakpoint raised `480px → 640px` to cover landscape phones and small tablets
- 3-column header restored at `≤640px` (collapses WCS badge column, matching pre-refactor behaviour)
- `pills-row` and `player-explanation` also hidden at `≤640px`

## Test plan

- [ ] On a 390px viewport (iPhone 14 Pro), card header shows avatar · name · star with no horizontal scroll
- [ ] On a 640px viewport, same — pills row and explanation hidden
- [ ] On a 800px+ viewport, pills row and explanation visible
- [ ] Dark mode unaffected

https://claude.ai/code/session_01TnXL41fX1vecQxzXCaaij4

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnXL41fX1vecQxzXCaaij4)_