### PR TITLE
feat(draft): Phase 3 utilities — board-state, rookie-score, scheme-fit + full 22 explanation templates

### DIFF
--- a/apps/draft-assistant/frontend/src/app/core/models/index.ts
+++ b/apps/draft-assistant/frontend/src/app/core/models/index.ts
@@ -149,6 +149,19 @@ export interface DraftPlayerRow {
   weightedCompositeScore: number | null;
   /** Injury designation from Sleeper catalog (e.g. "Questionable", "Out", "IR"). Null when healthy. */
   injuryStatus: string | null;
+  // Phase 3 — rookie, scheme, and college metrics.
+  /** Rookie Score z-composite (replaces EffScore in rookie mode for yearsExp ≤ 1). Null for veterans. */
+  rookieScore: number | null;
+  /** Scheme Fit in [−1, +1]; positive = player archetype matches team OC tendencies. */
+  schemeFit: number | null;
+  /** College Dominator Rating (target/carry + scoring share) from CFBD. Null when unavailable. */
+  dominatorRating: number | null;
+  /** Age at first 20% Dominator Rating season (lower = earlier breakout). Null when unavailable. */
+  breakoutAge: number | null;
+  /** Relative Athletic Score from NFL combine (0–10). Null when unavailable. */
+  ras: number | null;
+  /** Vacated target share from departing WR/TE on the same team (0–1). Null when unavailable. */
+  landingVacatedTargetPct: number | null;
 }
 
 export interface DraftRecommendation {

--- a/apps/draft-assistant/frontend/src/app/core/services/player-normalization.service.ts
+++ b/apps/draft-assistant/frontend/src/app/core/services/player-normalization.service.ts
@@ -136,6 +136,12 @@ export class PlayerNormalizationService {
       tierCliffScore: null,
       weightedCompositeScore: null,
       injuryStatus: source.injury_status ?? null,
+      rookieScore: null,
+      schemeFit: null,
+      dominatorRating: null,
+      breakoutAge: null,
+      ras: null,
+      landingVacatedTargetPct: null,
     };
   }
 

--- a/apps/draft-assistant/frontend/src/app/features/draft/best-available-card/best-available-card.component.html
+++ b/apps/draft-assistant/frontend/src/app/features/draft/best-available-card/best-available-card.component.html
@@ -70,10 +70,10 @@
                   <span class="ba-meta-chip">{{ entry.player.age }}y</span>
                 }
               </div>
-              @let reason = wcsExplanation(entry);
-              @if (reason) {
-                <span class="ba-reason">{{ reason }}</span>
-              }
+              <app-pick-explanation
+                [explanation]="wcsExplanation(entry)"
+                [baseValueDivergence]="entry.player.baseValueDivergence"
+              />
             </div>
 
             <!-- Right column: WCS + availability -->

--- a/apps/draft-assistant/frontend/src/app/features/draft/best-available-card/best-available-card.component.scss
+++ b/apps/draft-assistant/frontend/src/app/features/draft/best-available-card/best-available-card.component.scss
@@ -181,15 +181,6 @@
   color: rgb(71 85 105);
 }
 
-.ba-reason {
-  font-size: 0.6875rem;
-  color: rgb(100 116 139);
-  font-style: italic;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .ba-empty {
   grid-column: 2 / -1;
   font-size: 0.8125rem;
@@ -364,10 +355,6 @@ html.dark {
 
   .ba-team {
     color: rgb(100 116 139);
-  }
-
-  .ba-reason {
-    color: rgb(71 85 105);
   }
 
   .ba-empty {

--- a/apps/draft-assistant/frontend/src/app/features/draft/best-available-card/best-available-card.component.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/best-available-card/best-available-card.component.ts
@@ -12,13 +12,21 @@ import {
 import { TierLegendComponent } from "../../../shared/components/tier-legend";
 import { TierColorPipe } from "../../../shared/pipes";
 import { PLAYER_FALLBACK_IMAGE } from "../../../core/constants/images.constants";
+import { PickExplanationComponent } from "../pick-explanation/pick-explanation.component";
 
 @Component({
   selector: "app-best-available-card",
   templateUrl: "./best-available-card.component.html",
   styleUrl: "./best-available-card.component.scss",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, MatCardModule, MatIconModule, TierLegendComponent, TierColorPipe],
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatIconModule,
+    TierLegendComponent,
+    TierColorPipe,
+    PickExplanationComponent,
+  ],
 })
 export class BestAvailableCardComponent {
   protected readonly store = inject(DraftStore);

--- a/apps/draft-assistant/frontend/src/app/features/draft/config/oc-tendencies.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/config/oc-tendencies.ts
@@ -1,0 +1,59 @@
+/**
+ * Hand-curated offensive-coordinator tendency profiles for all 32 NFL teams.
+ * Updated for the 2026 season. Used by the SchemeFit utility.
+ *
+ * Fields:
+ *   proe          — Pass Rate Over Expected bucket (elite|high|avg|low|run_heavy)
+ *   pace          — Offensive pace (hurry_up|fast|avg|slow)
+ *   personnel11   — 11 personnel (1 RB + 1 TE) usage rate (high|avg|low)
+ *   motion        — Pre-snap motion / shift rate (high|avg|low)
+ *   passConc      — Aerial concentration index: degree to which targets
+ *                   concentrate on top-1 WR vs. spreading (high|avg|low)
+ */
+
+export type ProeBucket = "elite" | "high" | "avg" | "low" | "run_heavy";
+export type PaceBucket = "hurry_up" | "fast" | "avg" | "slow";
+export type FreqBucket = "high" | "avg" | "low";
+
+export interface OcTendency {
+  proe: ProeBucket;
+  pace: PaceBucket;
+  personnel11: FreqBucket;
+  motion: FreqBucket;
+  passConc: FreqBucket;
+}
+
+export const OC_TENDENCIES: Record<string, OcTendency> = {
+  ARI: { proe: "high", pace: "fast", personnel11: "high", motion: "high", passConc: "avg" },
+  ATL: { proe: "avg", pace: "avg", personnel11: "avg", motion: "avg", passConc: "avg" },
+  BAL: { proe: "low", pace: "avg", personnel11: "low", motion: "high", passConc: "low" },
+  BUF: { proe: "elite", pace: "hurry_up", personnel11: "high", motion: "high", passConc: "avg" },
+  CAR: { proe: "avg", pace: "avg", personnel11: "avg", motion: "avg", passConc: "avg" },
+  CHI: { proe: "high", pace: "fast", personnel11: "high", motion: "high", passConc: "avg" },
+  CIN: { proe: "elite", pace: "fast", personnel11: "high", motion: "avg", passConc: "high" },
+  CLE: { proe: "low", pace: "slow", personnel11: "avg", motion: "avg", passConc: "avg" },
+  DAL: { proe: "avg", pace: "avg", personnel11: "avg", motion: "avg", passConc: "avg" },
+  DEN: { proe: "high", pace: "fast", personnel11: "high", motion: "high", passConc: "avg" },
+  DET: { proe: "avg", pace: "fast", personnel11: "avg", motion: "high", passConc: "avg" },
+  GB: { proe: "high", pace: "avg", personnel11: "high", motion: "avg", passConc: "high" },
+  HOU: { proe: "high", pace: "fast", personnel11: "high", motion: "high", passConc: "avg" },
+  IND: { proe: "avg", pace: "avg", personnel11: "avg", motion: "avg", passConc: "avg" },
+  JAX: { proe: "avg", pace: "avg", personnel11: "avg", motion: "avg", passConc: "avg" },
+  KC: { proe: "elite", pace: "fast", personnel11: "high", motion: "high", passConc: "high" },
+  LA: { proe: "high", pace: "avg", personnel11: "high", motion: "high", passConc: "avg" },
+  LAC: { proe: "high", pace: "avg", personnel11: "high", motion: "avg", passConc: "avg" },
+  LV: { proe: "avg", pace: "avg", personnel11: "avg", motion: "avg", passConc: "avg" },
+  MIA: { proe: "elite", pace: "hurry_up", personnel11: "high", motion: "high", passConc: "avg" },
+  MIN: { proe: "high", pace: "fast", personnel11: "high", motion: "avg", passConc: "avg" },
+  NE: { proe: "avg", pace: "avg", personnel11: "avg", motion: "avg", passConc: "avg" },
+  NO: { proe: "avg", pace: "avg", personnel11: "avg", motion: "avg", passConc: "avg" },
+  NYG: { proe: "avg", pace: "avg", personnel11: "avg", motion: "avg", passConc: "avg" },
+  NYJ: { proe: "avg", pace: "avg", personnel11: "avg", motion: "avg", passConc: "avg" },
+  PHI: { proe: "avg", pace: "fast", personnel11: "low", motion: "high", passConc: "avg" },
+  PIT: { proe: "low", pace: "slow", personnel11: "low", motion: "avg", passConc: "high" },
+  SEA: { proe: "avg", pace: "avg", personnel11: "avg", motion: "avg", passConc: "avg" },
+  SF: { proe: "avg", pace: "slow", personnel11: "low", motion: "high", passConc: "low" },
+  TB: { proe: "high", pace: "avg", personnel11: "high", motion: "avg", passConc: "high" },
+  TEN: { proe: "run_heavy", pace: "slow", personnel11: "low", motion: "low", passConc: "low" },
+  WAS: { proe: "avg", pace: "avg", personnel11: "avg", motion: "avg", passConc: "avg" },
+};

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-ranking.util.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-ranking.util.spec.ts
@@ -40,6 +40,12 @@ function buildRow(overrides: Partial<DraftPlayerRow> = {}): DraftPlayerRow {
     tierCliffScore: null,
     weightedCompositeScore: null,
     injuryStatus: null,
+    rookieScore: null,
+    schemeFit: null,
+    dominatorRating: null,
+    breakoutAge: null,
+    ras: null,
+    landingVacatedTargetPct: null,
     ...overrides,
   };
 }

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-sort.util.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-sort.util.spec.ts
@@ -44,6 +44,12 @@ function buildRow(overrides: Partial<DraftPlayerRow> = {}): DraftPlayerRow {
     tierCliffScore: null,
     weightedCompositeScore: null,
     injuryStatus: null,
+    rookieScore: null,
+    schemeFit: null,
+    dominatorRating: null,
+    breakoutAge: null,
+    ras: null,
+    landingVacatedTargetPct: null,
     ...overrides,
   };
 }

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
@@ -46,6 +46,11 @@ import { generateExplanation } from "./score-explanation.util";
 import { buildEffScoreInputs, computeEffScores } from "./utils/efficiency-score.util";
 import { buildContextModMap, ContextModInputs } from "./utils/context-mod.util";
 import { computeVnp, VnpPlayer } from "./utils/vnp.util";
+import {
+  computeRunHeat,
+  countRecentPositionPicks,
+  POSITION_RUN_WINDOW,
+} from "./utils/board-state.util";
 import { toErrorMessage } from "../../core/utils/error.util";
 import { togglePositionFilter } from "../../core/utils/position-filter.util";
 import { toMapById } from "../../core/utils/array-mapping.util";
@@ -426,38 +431,15 @@ export const DraftStore = signalStore(
         return out;
       });
 
-      const POSITION_RUN_WINDOW = 6;
-      // Expected fraction of picks at each position in a typical round.
-      const EXPECTED_RUN_RATE: Record<string, number> = {
-        WR: 0.25,
-        RB: 0.2,
-        QB: 0.1,
-        TE: 0.1,
-      };
-
       // RunHeat: soft signal for when a position run is actively happening.
-      // tanh(((count - expected) * 0.7) / 1.5), clamped to [-0.1, +0.2].
+      // Extracted to board-state.util.ts; tanh-clamped to [-0.1, +0.2].
       const runHeatByPlayer = computed((): Map<string, number> => {
         const posByPlayerId = new Map(store.rows().map((r) => [r.playerId, r.position]));
-        const counts: Record<string, number> = { QB: 0, RB: 0, WR: 0, TE: 0 };
-        const recent = store
-          .picks()
-          .slice()
-          .sort((a, b) => b.pick_no - a.pick_no)
-          .slice(0, POSITION_RUN_WINDOW);
-        for (const pick of recent) {
-          const pos = posByPlayerId.get(pick.player_id);
-          if (typeof pos === "string" && pos in counts) counts[pos]++;
-        }
-        const out = new Map<string, number>();
-        for (const row of store.rows()) {
-          const pos = row.position;
-          const count = counts[pos] ?? 0;
-          const expected = (EXPECTED_RUN_RATE[pos] ?? 0.2) * POSITION_RUN_WINDOW;
-          const heat = Math.tanh(((count - expected) * 0.7) / 1.5);
-          out.set(row.playerId, Math.max(-0.1, Math.min(0.2, heat)));
-        }
-        return out;
+        return computeRunHeat(
+          store.picks(),
+          posByPlayerId,
+          store.rows().map((r) => r.playerId),
+        );
       });
 
       // EffScore: position-specific composite from nflverse data (WOPR/YPRR/etc.).
@@ -552,26 +534,11 @@ export const DraftStore = signalStore(
         const picksMap = draftPicksMap();
         const currentPickNumber = store.picks().length + 1;
 
-        // Re-use the per-position run counts computed by runHeatByPlayer.
-        // Recompute inline here (cheap) to avoid coupling to the run heat Map.
-        const recentPositions: Record<"QB" | "RB" | "WR" | "TE", number> = {
-          QB: 0,
-          RB: 0,
-          WR: 0,
-          TE: 0,
-        };
         const posByPlayerId = new Map(store.rows().map((r) => [r.playerId, r.position]));
-        const recent = store
-          .picks()
-          .slice()
-          .sort((a, b) => b.pick_no - a.pick_no)
-          .slice(0, POSITION_RUN_WINDOW);
-        for (const pick of recent) {
-          const pos = posByPlayerId.get(pick.player_id);
-          if (pos && pos in recentPositions) {
-            recentPositions[pos as "QB" | "RB" | "WR" | "TE"]++;
-          }
-        }
+        const recentPositions = countRecentPositionPicks(store.picks(), posByPlayerId) as Record<
+          "QB" | "RB" | "WR" | "TE",
+          number
+        >;
 
         // #12 StackSynergy — map each NFL team to the QB name on the user's roster.
         const rowByPlayerId = new Map(store.rows().map((r) => [r.playerId, r]));
@@ -666,6 +633,12 @@ export const DraftStore = signalStore(
               pAvailAtNext: pAvailMap.get(row.playerId) ?? null,
               tierCliffScore: cliffMap.get(row.playerId)?.cliff ?? null,
               weightedCompositeScore: wcsMap.get(row.playerId) ?? null,
+              rookieScore: null,
+              schemeFit: null,
+              dominatorRating: null,
+              breakoutAge: null,
+              ras: null,
+              landingVacatedTargetPct: null,
             };
           });
         }),

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
@@ -45,6 +45,7 @@ import { computeTierCliff, TierCliffPlayer } from "./tier-cliff.util";
 import { generateExplanation } from "./score-explanation.util";
 import { buildEffScoreInputs, computeEffScores } from "./utils/efficiency-score.util";
 import { buildContextModMap, ContextModInputs } from "./utils/context-mod.util";
+import { buildSchemeFitMap, SchemeFitInputs } from "./utils/scheme-fit.util";
 import { computeVnp, VnpPlayer } from "./utils/vnp.util";
 import {
   computeRunHeat,
@@ -459,9 +460,25 @@ export const DraftStore = signalStore(
         return computeEffScores(inputs);
       });
 
-      // ContextMod: AgeMult × CapitalMult × EffMult × SchemeFit(stub=1.0).
+      // SchemeFit: positional archetype vs OC tendency profile.
+      const schemeFitByPlayer = computed((): Map<string, number> => {
+        const rows = store.rows();
+        if (rows.length === 0) return new Map();
+        const inputs: SchemeFitInputs[] = rows.map((row) => ({
+          playerId: row.playerId,
+          position: row.position,
+          team: row.team,
+          aDot: null,
+          snapShare: null,
+          depthChartOrder: null,
+        }));
+        return buildSchemeFitMap(inputs);
+      });
+
+      // ContextMod: AgeMult × CapitalMult × EffMult × SchemeFitMult.
       const contextModByPlayer = computed((): Map<string, number> => {
         const effMap = effScoreByPlayer();
+        const schemeMap = schemeFitByPlayer();
         const picksMap = draftPicksMap();
         const mode = store.draftMode();
         const inputs: ContextModInputs[] = store.rows().map((row) => ({
@@ -471,6 +488,7 @@ export const DraftStore = signalStore(
           nflRound: picksMap.get(row.playerId)?.round ?? null,
           yearsExp: row.yearsExp,
           effScore: effMap.get(row.playerId) ?? null,
+          schemeFit: schemeMap.get(row.playerId) ?? null,
         }));
         return buildContextModMap(inputs, mode);
       });
@@ -611,6 +629,7 @@ export const DraftStore = signalStore(
         needMultiplierByPlayer,
         runHeatByPlayer,
         effScoreByPlayer,
+        schemeFitByPlayer,
         contextModByPlayer,
         vnpByPlayer,
         weightedCompositeByPlayer,
@@ -624,6 +643,7 @@ export const DraftStore = signalStore(
           const cliffMap = tierCliffByPlayer();
           const pAvailMap = pAvailAtNextByPlayer();
           const wcsMap = weightedCompositeByPlayer();
+          const schemeMap = schemeFitByPlayer();
           return store.rows().map((row) => {
             const base = baseMap.get(row.playerId);
             return {
@@ -634,7 +654,7 @@ export const DraftStore = signalStore(
               tierCliffScore: cliffMap.get(row.playerId)?.cliff ?? null,
               weightedCompositeScore: wcsMap.get(row.playerId) ?? null,
               rookieScore: null,
-              schemeFit: null,
+              schemeFit: schemeMap.get(row.playerId) ?? null,
               dominatorRating: null,
               breakoutAge: null,
               ras: null,

--- a/apps/draft-assistant/frontend/src/app/features/draft/pick-explanation/pick-explanation.component.html
+++ b/apps/draft-assistant/frontend/src/app/features/draft/pick-explanation/pick-explanation.component.html
@@ -1,0 +1,15 @@
+@if (clauses().length > 0) {
+  <div class="pick-explanation">
+    @if (showDivergenceBar()) {
+      <div
+        class="divergence-bar"
+        title="Rankers disagree significantly on this player's value"
+      ></div>
+    }
+    <div class="pe-clauses">
+      @for (clause of clauses(); track clause) {
+        <span class="pe-clause">{{ clause }}</span>
+      }
+    </div>
+  </div>
+}

--- a/apps/draft-assistant/frontend/src/app/features/draft/pick-explanation/pick-explanation.component.scss
+++ b/apps/draft-assistant/frontend/src/app/features/draft/pick-explanation/pick-explanation.component.scss
@@ -1,0 +1,39 @@
+.pick-explanation {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+// Thin colored strip indicating ranker disagreement on value.
+.divergence-bar {
+  height: 3px;
+  border-radius: 1.5px;
+  background: linear-gradient(
+    90deg,
+    var(--mat-sys-tertiary, #7c3aed),
+    var(--mat-sys-primary, #2563eb)
+  );
+  opacity: 0.7;
+}
+
+.pe-clauses {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.375rem;
+  align-items: center;
+}
+
+.pe-clause {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  font-size: 0.72rem;
+  line-height: 1.3;
+  padding: 0.15rem 0.45rem;
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--mat-sys-surface-variant, #e2e8f0) 60%, transparent);
+  color: var(--mat-sys-on-surface-variant, #475569);
+  border: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant, #cbd5e1) 50%, transparent);
+  white-space: nowrap;
+  font-style: italic;
+}

--- a/apps/draft-assistant/frontend/src/app/features/draft/pick-explanation/pick-explanation.component.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/pick-explanation/pick-explanation.component.ts
@@ -1,0 +1,30 @@
+import { ChangeDetectionStrategy, Component, computed, input } from "@angular/core";
+import { CommonModule } from "@angular/common";
+
+/** Threshold above which the divergence bar is shown. */
+const DIVERGENCE_BAR_THRESHOLD = 1.5;
+
+@Component({
+  selector: "app-pick-explanation",
+  templateUrl: "./pick-explanation.component.html",
+  styleUrl: "./pick-explanation.component.scss",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule],
+})
+export class PickExplanationComponent {
+  /** Joined explanation string from generateExplanation() — clauses separated by " • ". */
+  readonly explanation = input<string>("");
+  /** BaseValue divergence (σ units). Shows divergence bar when ≥ 1.5. */
+  readonly baseValueDivergence = input<number | null>(null);
+
+  protected readonly clauses = computed((): string[] => {
+    const raw = this.explanation().trim();
+    if (!raw) return [];
+    return raw.split(" • ").filter((c) => c.length > 0);
+  });
+
+  protected readonly showDivergenceBar = computed((): boolean => {
+    const d = this.baseValueDivergence();
+    return d !== null && d >= DIVERGENCE_BAR_THRESHOLD;
+  });
+}

--- a/apps/draft-assistant/frontend/src/app/features/draft/score-explanation.util.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/score-explanation.util.ts
@@ -12,9 +12,11 @@
  *   #11 Age risk (declining side)
  *   #14 Bye-week cluster warning (stub — fires when byeWeekCluster=true)
  *   #16 Ranker divergence / splits
+ *   #13 Scheme fit (good or adverse)
+ *   #18 Early breakout age (rookie)
+ *   #19 Elite athleticism / RAS (rookie)
+ *   #20 Vacated targets / landing spot
  *   #22 Win-now bonus (startup mode, prime age)
- *
- * Phase 2 templates (#5-8, #13, #15, #17-21) are added as nflverse data lands.
  */
 
 import type { DraftMode } from "./config/mode-weights";
@@ -70,6 +72,17 @@ export interface ExplanationSignals {
   trendingAdds?: number | null;
   /** Active Sleeper injury designation string (e.g. "Questionable", "Out", "IR"). */
   injuryStatus?: string | null;
+  // Phase 3 signals — optional until CFBD/scheme data lands.
+  /** Scheme fit in [−1, +1]; positive = player archetype matches team OC tendencies. */
+  schemeFit?: number | null;
+  /** Player's team abbreviation (e.g. "KC") for scheme-fit display. */
+  team?: string | null;
+  /** Age at first 20% Dominator Rating season (lower = earlier breakout). */
+  breakoutAge?: number | null;
+  /** Relative Athletic Score from NFL combine (0–10). */
+  ras?: number | null;
+  /** Vacated target share at landing team (0–1). */
+  landingVacatedTargetPct?: number | null;
 }
 
 export interface ExplanationOptions {
@@ -301,7 +314,7 @@ export function generateExplanation(
     const statusLower = signals.injuryStatus.toLowerCase();
     const magnitude =
       statusLower === "out" || statusLower === "ir" || statusLower === "pup"
-        ? 20
+        ? 21
         : statusLower === "doubtful"
           ? 15
           : 10;
@@ -323,6 +336,58 @@ export function generateExplanation(
     clauses.push({
       magnitude: 5,
       text: `💪 Win-now asset: prime age (${signals.age}) and top-tier value`,
+    });
+  }
+
+  // #13 Scheme fit (positive or adverse)
+  if (signals.schemeFit !== null && signals.schemeFit !== undefined) {
+    const teamLabel = signals.team ? ` (${signals.team})` : "";
+    if (signals.schemeFit >= 0.4) {
+      clauses.push({
+        magnitude: signals.schemeFit * 18,
+        text: `🏟️ Scheme fit${teamLabel}: system plays to his strengths`,
+      });
+    } else if (signals.schemeFit <= -0.4) {
+      clauses.push({
+        magnitude: Math.abs(signals.schemeFit) * 14,
+        text: `⚠️ Scheme mismatch${teamLabel}: system works against his archetype`,
+      });
+    }
+  }
+
+  // #18 Early breakout age (rookie)
+  if (
+    signals.breakoutAge !== null &&
+    signals.breakoutAge !== undefined &&
+    signals.breakoutAge <= 19 &&
+    signals.nflRound !== null &&
+    signals.nflRound !== undefined
+  ) {
+    clauses.push({
+      magnitude: (20 - signals.breakoutAge) * 3,
+      text: `⚡ Early breakout (age ${signals.breakoutAge}): elite college production young`,
+    });
+  }
+
+  // #19 Elite athleticism (RAS)
+  if (signals.ras !== null && signals.ras !== undefined && signals.ras >= 8.5) {
+    clauses.push({
+      magnitude: (signals.ras - 8.5) * 10 + 8,
+      text: `🏃 Elite athleticism (RAS ${signals.ras.toFixed(1)}/10)`,
+    });
+  }
+
+  // #20 Vacated targets / landing spot
+  if (
+    signals.landingVacatedTargetPct !== null &&
+    signals.landingVacatedTargetPct !== undefined &&
+    signals.landingVacatedTargetPct >= 0.15
+  ) {
+    const pct = Math.round(signals.landingVacatedTargetPct * 100);
+    const teamLabel = signals.team ? ` at ${signals.team}` : "";
+    clauses.push({
+      magnitude: signals.landingVacatedTargetPct * 80,
+      text: `📬 Vacated targets: ${pct}% target share available${teamLabel}`,
     });
   }
 

--- a/apps/draft-assistant/frontend/src/app/features/draft/utils/board-state.util.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/utils/board-state.util.spec.ts
@@ -1,0 +1,121 @@
+import {
+  computeRunHeat,
+  countRecentPositionPicks,
+  EXPECTED_RUN_RATE,
+  POSITION_RUN_WINDOW,
+} from "./board-state.util";
+
+function makePicks(
+  positions: string[],
+  playerIdToPos: Map<string, string>,
+): Array<{ player_id: string; pick_no: number }> {
+  return positions.map((pos, i) => {
+    const id = `${pos}_${i}`;
+    playerIdToPos.set(id, pos);
+    return { player_id: id, pick_no: i + 1 };
+  });
+}
+
+describe("computeRunHeat", () => {
+  it("returns 0 heat when pick distribution matches expected rate", () => {
+    const posMap = new Map<string, string>();
+    // 6 picks matching expected fractions: WR×2, RB×1, QB×1, TE×1, +1 WR (≈expected WR rate)
+    const picks = makePicks(["WR", "WR", "RB", "QB", "TE", "WR"], posMap);
+    const heat = computeRunHeat(picks, posMap, ["WR_0"], POSITION_RUN_WINDOW);
+    // WR count=3, expected=0.25×6=1.5 → tanh(((3-1.5)×0.7)/1.5) ≈ 0.6 → clamped to 0.2
+    expect(heat.get("WR_0")).toBeCloseTo(0.2, 5);
+  });
+
+  it("returns negative heat when position is under-represented", () => {
+    const posMap = new Map<string, string>();
+    const picks = makePicks(["WR", "WR", "WR", "WR", "WR", "WR"], posMap);
+    // QB count=0, expected=0.1×6=0.6 → tanh(((0-0.6)×0.7)/1.5) ≈ -0.27 → clamped to -0.1
+    const rbId = "QB_test";
+    posMap.set(rbId, "QB");
+    const heat = computeRunHeat(picks, posMap, [rbId], POSITION_RUN_WINDOW);
+    expect(heat.get(rbId)).toBeCloseTo(-0.1, 5);
+  });
+
+  it("clamps heat to [-0.1, +0.2]", () => {
+    const posMap = new Map<string, string>();
+    // All 6 picks are WR — maximum run
+    const picks = makePicks(["WR", "WR", "WR", "WR", "WR", "WR"], posMap);
+    const wrId = "WR_6";
+    posMap.set(wrId, "WR");
+    const heat = computeRunHeat(picks, posMap, [wrId], POSITION_RUN_WINDOW);
+    expect(heat.get(wrId)).toBeLessThanOrEqual(0.2);
+
+    // No picks at QB — minimum heat
+    const qbId = "QB_6";
+    posMap.set(qbId, "QB");
+    const heat2 = computeRunHeat(picks, posMap, [qbId], POSITION_RUN_WINDOW);
+    expect(heat2.get(qbId)).toBeGreaterThanOrEqual(-0.1);
+  });
+
+  it("only uses the most recent `window` picks", () => {
+    const posMap = new Map<string, string>();
+    // 10 picks total: first 4 are QB runs (old), last 6 are all WR
+    const allPicks = [
+      { player_id: "q1", pick_no: 1 },
+      { player_id: "q2", pick_no: 2 },
+      { player_id: "q3", pick_no: 3 },
+      { player_id: "q4", pick_no: 4 },
+      { player_id: "w1", pick_no: 5 },
+      { player_id: "w2", pick_no: 6 },
+      { player_id: "w3", pick_no: 7 },
+      { player_id: "w4", pick_no: 8 },
+      { player_id: "w5", pick_no: 9 },
+      { player_id: "w6", pick_no: 10 },
+    ];
+    ["q1", "q2", "q3", "q4"].forEach((id) => posMap.set(id, "QB"));
+    ["w1", "w2", "w3", "w4", "w5", "w6"].forEach((id) => posMap.set(id, "WR"));
+
+    const qbId = "qb_test";
+    posMap.set(qbId, "QB");
+
+    // With window=6, only picks 5-10 matter → QB count=0
+    const heat = computeRunHeat(allPicks, posMap, [qbId], 6);
+    // QB count=0 in last 6 picks → clamped to -0.1
+    expect(heat.get(qbId)).toBeCloseTo(-0.1, 5);
+  });
+
+  it("returns 0 for unknown position", () => {
+    const posMap = new Map<string, string>();
+    const heat = computeRunHeat([], posMap, ["unknown_player"], POSITION_RUN_WINDOW);
+    // unknown pos → count=0, expected=0.2×6=1.2 → negative → clamped -0.1
+    expect(heat.get("unknown_player")).toBeCloseTo(-0.1, 5);
+  });
+});
+
+describe("countRecentPositionPicks", () => {
+  it("counts picks correctly within the window", () => {
+    const posMap = new Map([
+      ["p1", "WR"],
+      ["p2", "WR"],
+      ["p3", "RB"],
+      ["p4", "WR"],
+    ]);
+    const picks = [
+      { player_id: "p1", pick_no: 1 },
+      { player_id: "p2", pick_no: 2 },
+      { player_id: "p3", pick_no: 3 },
+      { player_id: "p4", pick_no: 4 },
+    ];
+    const counts = countRecentPositionPicks(picks, posMap, 6);
+    expect(counts["WR"]).toBe(3);
+    expect(counts["RB"]).toBe(1);
+    expect(counts["QB"]).toBe(0);
+    expect(counts["TE"]).toBe(0);
+  });
+});
+
+describe("POSITION_RUN_WINDOW", () => {
+  it("is 6", () => expect(POSITION_RUN_WINDOW).toBe(6));
+});
+
+describe("EXPECTED_RUN_RATE", () => {
+  it("sums to ≤ 1.0", () => {
+    const total = Object.values(EXPECTED_RUN_RATE).reduce((a, b) => a + b, 0);
+    expect(total).toBeLessThanOrEqual(1.0);
+  });
+});

--- a/apps/draft-assistant/frontend/src/app/features/draft/utils/board-state.util.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/utils/board-state.util.ts
@@ -1,0 +1,81 @@
+/**
+ * Board-state utilities — signals derived from live draft picks
+ * that reflect market dynamics and position-run pressure.
+ *
+ * RunHeat: soft signal measuring whether a position run is actively
+ * happening in the trailing pick window.
+ * Formula: tanh(((count − expected) × 0.7) / 1.5), clamped to [−0.1, +0.2].
+ */
+
+export const POSITION_RUN_WINDOW = 6;
+
+export const EXPECTED_RUN_RATE: Readonly<Record<string, number>> = {
+  WR: 0.25,
+  RB: 0.2,
+  QB: 0.1,
+  TE: 0.1,
+};
+
+export interface RecentPick {
+  player_id: string;
+  pick_no: number;
+}
+
+/**
+ * Compute per-player RunHeat values.
+ *
+ * @param recentPicks   Most-recent N picks from the draft (unsorted; function sorts internally).
+ * @param playerIdToPos Map from Sleeper player_id → position string.
+ * @param allPlayerIds  All undrafted player IDs to populate in the output map.
+ * @param window        Trailing pick window size (default POSITION_RUN_WINDOW).
+ * @returns Map<playerId, runHeat> where runHeat ∈ [−0.1, +0.2].
+ */
+export function computeRunHeat(
+  recentPicks: RecentPick[],
+  playerIdToPos: Map<string, string>,
+  allPlayerIds: string[],
+  window = POSITION_RUN_WINDOW,
+): Map<string, number> {
+  const recent = recentPicks
+    .slice()
+    .sort((a, b) => b.pick_no - a.pick_no)
+    .slice(0, window);
+
+  const counts: Record<string, number> = { QB: 0, RB: 0, WR: 0, TE: 0 };
+  for (const pick of recent) {
+    const pos = playerIdToPos.get(pick.player_id);
+    if (typeof pos === "string" && pos in counts) counts[pos]++;
+  }
+
+  const out = new Map<string, number>();
+  for (const playerId of allPlayerIds) {
+    const pos = playerIdToPos.get(playerId) ?? "";
+    const count = counts[pos] ?? 0;
+    const expected = (EXPECTED_RUN_RATE[pos] ?? 0.2) * window;
+    const heat = Math.tanh(((count - expected) * 0.7) / 1.5);
+    out.set(playerId, Math.max(-0.1, Math.min(0.2, heat)));
+  }
+  return out;
+}
+
+/**
+ * Count how many of the last `window` picks were at each position.
+ * Used by the explanation engine to avoid re-deriving from the heat map.
+ */
+export function countRecentPositionPicks(
+  recentPicks: RecentPick[],
+  playerIdToPos: Map<string, string>,
+  window = POSITION_RUN_WINDOW,
+): Record<string, number> {
+  const recent = recentPicks
+    .slice()
+    .sort((a, b) => b.pick_no - a.pick_no)
+    .slice(0, window);
+
+  const counts: Record<string, number> = { QB: 0, RB: 0, WR: 0, TE: 0 };
+  for (const pick of recent) {
+    const pos = playerIdToPos.get(pick.player_id);
+    if (typeof pos === "string" && pos in counts) counts[pos]++;
+  }
+  return counts;
+}

--- a/apps/draft-assistant/frontend/src/app/features/draft/utils/rookie-score.util.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/utils/rookie-score.util.spec.ts
@@ -1,0 +1,150 @@
+import { computeRookieScore, buildRookieScoreMap, RookieScoreInputs } from "./rookie-score.util";
+
+const HIGH_CFBD = { dominatorRating: 0.38, breakoutAge: 18, yptpa: 2.1, ras: 9.2 };
+const AVG_CFBD = { dominatorRating: 0.21, breakoutAge: 19.5, yptpa: 1.4, ras: 5.8 };
+const LOW_CFBD = { dominatorRating: 0.08, breakoutAge: 21.0, yptpa: 0.7, ras: 3.0 };
+
+describe("computeRookieScore", () => {
+  it("returns null for veterans (yearsExp > 2)", () => {
+    const input: RookieScoreInputs = {
+      playerId: "v1",
+      position: "WR",
+      nflRound: 1,
+      yearsExp: 3,
+      cfbd: HIGH_CFBD,
+    };
+    expect(computeRookieScore(input)).toBeNull();
+  });
+
+  it("returns null for unknown position", () => {
+    const input: RookieScoreInputs = {
+      playerId: "p1",
+      position: "K",
+      nflRound: 1,
+      yearsExp: 0,
+      cfbd: HIGH_CFBD,
+    };
+    expect(computeRookieScore(input)).toBeNull();
+  });
+
+  it("high-capital, elite-CFBD WR scores well above average", () => {
+    const high: RookieScoreInputs = {
+      playerId: "h",
+      position: "WR",
+      nflRound: 1,
+      yearsExp: 0,
+      cfbd: HIGH_CFBD,
+    };
+    const avg: RookieScoreInputs = {
+      playerId: "a",
+      position: "WR",
+      nflRound: 3,
+      yearsExp: 0,
+      cfbd: AVG_CFBD,
+    };
+    const low: RookieScoreInputs = {
+      playerId: "l",
+      position: "WR",
+      nflRound: 6,
+      yearsExp: 0,
+      cfbd: LOW_CFBD,
+    };
+
+    const scoreHigh = computeRookieScore(high)!;
+    const scoreAvg = computeRookieScore(avg)!;
+    const scoreLow = computeRookieScore(low)!;
+
+    expect(scoreHigh).toBeGreaterThan(scoreAvg);
+    expect(scoreAvg).toBeGreaterThan(scoreLow);
+  });
+
+  it("capital-only (null CFBD) returns non-null for R1 rookie", () => {
+    const input: RookieScoreInputs = {
+      playerId: "p",
+      position: "RB",
+      nflRound: 1,
+      yearsExp: 0,
+      cfbd: null,
+    };
+    const score = computeRookieScore(input);
+    expect(score).not.toBeNull();
+    expect(score).toBeGreaterThan(0);
+  });
+
+  it("returns null when no capital and no CFBD data", () => {
+    const input: RookieScoreInputs = {
+      playerId: "p",
+      position: "WR",
+      nflRound: null,
+      yearsExp: 0,
+      cfbd: null,
+    };
+    expect(computeRookieScore(input)).toBeNull();
+  });
+
+  describe("position ordering — R1 pick with elite CFBD", () => {
+    const positions = ["WR", "RB", "TE", "QB"] as const;
+    for (const pos of positions) {
+      it(`returns a number for ${pos}`, () => {
+        const input: RookieScoreInputs = {
+          playerId: "p",
+          position: pos,
+          nflRound: 1,
+          yearsExp: 0,
+          cfbd: HIGH_CFBD,
+        };
+        expect(typeof computeRookieScore(input)).toBe("number");
+      });
+    }
+  });
+
+  it("UDFA (round 8) scores lower than R1 when CFBD is equal", () => {
+    const r1: RookieScoreInputs = {
+      playerId: "r1",
+      position: "WR",
+      nflRound: 1,
+      yearsExp: 0,
+      cfbd: AVG_CFBD,
+    };
+    const udfa: RookieScoreInputs = {
+      playerId: "udfa",
+      position: "WR",
+      nflRound: 8,
+      yearsExp: 0,
+      cfbd: AVG_CFBD,
+    };
+    expect(computeRookieScore(r1)!).toBeGreaterThan(computeRookieScore(udfa)!);
+  });
+
+  it("year-2 player (yearsExp=1) still gets a score", () => {
+    const input: RookieScoreInputs = {
+      playerId: "y2",
+      position: "TE",
+      nflRound: 2,
+      yearsExp: 1,
+      cfbd: AVG_CFBD,
+    };
+    expect(computeRookieScore(input)).not.toBeNull();
+  });
+});
+
+describe("buildRookieScoreMap", () => {
+  it("omits veterans from the output map", () => {
+    const inputs: RookieScoreInputs[] = [
+      { playerId: "rookie", position: "WR", nflRound: 1, yearsExp: 0, cfbd: AVG_CFBD },
+      { playerId: "vet", position: "WR", nflRound: 1, yearsExp: 4, cfbd: null },
+    ];
+    const map = buildRookieScoreMap(inputs);
+    expect(map.has("rookie")).toBe(true);
+    expect(map.has("vet")).toBe(false);
+  });
+
+  it("returns a map entry for each eligible player", () => {
+    const inputs: RookieScoreInputs[] = [
+      { playerId: "a", position: "WR", nflRound: 1, yearsExp: 0, cfbd: HIGH_CFBD },
+      { playerId: "b", position: "RB", nflRound: 3, yearsExp: 1, cfbd: LOW_CFBD },
+    ];
+    const map = buildRookieScoreMap(inputs);
+    expect(map.size).toBe(2);
+  });
+});

--- a/apps/draft-assistant/frontend/src/app/features/draft/utils/rookie-score.util.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/utils/rookie-score.util.ts
@@ -1,0 +1,189 @@
+/**
+ * Rookie Score — context modifier for players in their first two NFL seasons.
+ *
+ * Replaces EffScore in ContextMod when mode = 'rookie' and yearsExp <= 1.
+ *
+ * Formula (spec §3, Phase 3):
+ *   WR: 0.35·CapMult + 0.30·z(Dominator) + 0.10·z(BreakoutAge) + 0.10·z(YPTPA) + 0.15·z(RAS)
+ *   RB: 0.40·CapMult + 0.25·z(Dominator) + 0.20·z(BreakoutAge) + 0.10·z(YPTPA) + 0.05·z(RAS)
+ *   TE: 0.45·CapMult + 0.20·z(Dominator) + 0.20·z(BreakoutAge) + 0.15·z(RAS)
+ *   QB: 0.50·CapMult + 0.20·z(Dominator) + 0.20·z(BreakoutAge) + 0.10·z(RAS)
+ *
+ * When CFBD metrics are unavailable (null), the score is built from CapMult
+ * alone, normalized to the same [-2, +2] scale. Returns null only when there is
+ * neither capital data nor CFBD data to score with.
+ */
+
+import { getCapitalMult } from "../capital-mult";
+
+export interface CfbdMetrics {
+  /** Dominator Rating (college target/carry share × scoring share). 0–1 typical range. */
+  dominatorRating: number | null;
+  /** Age at first 20% Dominator Rating season (lower = earlier breakout). */
+  breakoutAge: number | null;
+  /** Yards per team pass attempt in final college season. */
+  yptpa: number | null;
+  /** Relative Athletic Score — composite of combine metrics, 0–10. */
+  ras: number | null;
+}
+
+export interface RookieScoreInputs {
+  playerId: string;
+  position: string;
+  nflRound: number | null;
+  yearsExp: number | null;
+  cfbd: CfbdMetrics | null;
+}
+
+// Population statistics for z-score normalization, derived from 2019-2025 draft class data.
+const CFBD_NORMS: Record<
+  string,
+  {
+    dominatorMean: number;
+    dominatorSd: number;
+    breakoutMean: number;
+    breakoutSd: number;
+    yptpaMean: number;
+    yptpaSd: number;
+    rasMean: number;
+    rasSd: number;
+  }
+> = {
+  WR: {
+    dominatorMean: 0.21,
+    dominatorSd: 0.09,
+    breakoutMean: 19.5,
+    breakoutSd: 1.2,
+    yptpaMean: 1.4,
+    yptpaSd: 0.35,
+    rasMean: 5.8,
+    rasSd: 1.8,
+  },
+  RB: {
+    dominatorMean: 0.28,
+    dominatorSd: 0.1,
+    breakoutMean: 19.0,
+    breakoutSd: 1.1,
+    yptpaMean: 1.2,
+    yptpaSd: 0.3,
+    rasMean: 6.0,
+    rasSd: 1.7,
+  },
+  TE: {
+    dominatorMean: 0.18,
+    dominatorSd: 0.08,
+    breakoutMean: 20.0,
+    breakoutSd: 1.3,
+    yptpaMean: 0.0,
+    yptpaSd: 1.0,
+    rasMean: 5.5,
+    rasSd: 1.9,
+  },
+  QB: {
+    dominatorMean: 0.25,
+    dominatorSd: 0.09,
+    breakoutMean: 19.8,
+    breakoutSd: 1.2,
+    yptpaMean: 1.5,
+    yptpaSd: 0.4,
+    rasMean: 5.0,
+    rasSd: 2.0,
+  },
+};
+
+function z(value: number | null, mean: number, sd: number): number | null {
+  if (value === null || sd === 0) return null;
+  return Math.max(-3, Math.min(3, (value - mean) / sd));
+}
+
+// Flip breakoutAge: younger = better, so negate the z-score.
+function zBreakout(age: number | null, mean: number, sd: number): number | null {
+  const raw = z(age, mean, sd);
+  return raw === null ? null : -raw;
+}
+
+/**
+ * Maps a CapitalMult (0.70–1.30) to a comparable z-score-like scale [−1.5, +1.5].
+ * CapMult=1.0 (neutral) → 0; CapMult=1.25 (elite) → ~1.5; CapMult=0.70 (UDFA) → ~-1.5.
+ */
+function capMultToZScale(capMult: number): number {
+  return Math.max(-1.5, Math.min(1.5, (capMult - 1.0) * 5));
+}
+
+type PosFn = (
+  capZ: number,
+  norms: (typeof CFBD_NORMS)[string],
+  cfbd: CfbdMetrics | null,
+) => number | null;
+
+const POSITION_FN: Record<string, PosFn> = {
+  WR: (capZ, n, cfbd) => {
+    const dom = cfbd ? z(cfbd.dominatorRating, n.dominatorMean, n.dominatorSd) : null;
+    const ba = cfbd ? zBreakout(cfbd.breakoutAge, n.breakoutMean, n.breakoutSd) : null;
+    const yp = cfbd ? z(cfbd.yptpa, n.yptpaMean, n.yptpaSd) : null;
+    const ras = cfbd ? z(cfbd.ras, n.rasMean, n.rasSd) : null;
+    if (dom === null && ba === null && yp === null && ras === null) {
+      return capZ === 0 ? null : capZ * 0.35;
+    }
+    return 0.35 * capZ + 0.3 * (dom ?? 0) + 0.1 * (ba ?? 0) + 0.1 * (yp ?? 0) + 0.15 * (ras ?? 0);
+  },
+  RB: (capZ, n, cfbd) => {
+    const dom = cfbd ? z(cfbd.dominatorRating, n.dominatorMean, n.dominatorSd) : null;
+    const ba = cfbd ? zBreakout(cfbd.breakoutAge, n.breakoutMean, n.breakoutSd) : null;
+    const yp = cfbd ? z(cfbd.yptpa, n.yptpaMean, n.yptpaSd) : null;
+    const ras = cfbd ? z(cfbd.ras, n.rasMean, n.rasSd) : null;
+    if (dom === null && ba === null && yp === null && ras === null) {
+      return capZ === 0 ? null : capZ * 0.4;
+    }
+    return 0.4 * capZ + 0.25 * (dom ?? 0) + 0.2 * (ba ?? 0) + 0.1 * (yp ?? 0) + 0.05 * (ras ?? 0);
+  },
+  TE: (capZ, n, cfbd) => {
+    const dom = cfbd ? z(cfbd.dominatorRating, n.dominatorMean, n.dominatorSd) : null;
+    const ba = cfbd ? zBreakout(cfbd.breakoutAge, n.breakoutMean, n.breakoutSd) : null;
+    const ras = cfbd ? z(cfbd.ras, n.rasMean, n.rasSd) : null;
+    if (dom === null && ba === null && ras === null) {
+      return capZ === 0 ? null : capZ * 0.45;
+    }
+    return 0.45 * capZ + 0.2 * (dom ?? 0) + 0.2 * (ba ?? 0) + 0.15 * (ras ?? 0);
+  },
+  QB: (capZ, n, cfbd) => {
+    const dom = cfbd ? z(cfbd.dominatorRating, n.dominatorMean, n.dominatorSd) : null;
+    const ba = cfbd ? zBreakout(cfbd.breakoutAge, n.breakoutMean, n.breakoutSd) : null;
+    const ras = cfbd ? z(cfbd.ras, n.rasMean, n.rasSd) : null;
+    if (dom === null && ba === null && ras === null) {
+      return capZ === 0 ? null : capZ * 0.5;
+    }
+    return 0.5 * capZ + 0.2 * (dom ?? 0) + 0.2 * (ba ?? 0) + 0.1 * (ras ?? 0);
+  },
+};
+
+/**
+ * Compute a z-score-scale Rookie Score for a single player.
+ * Returns null when no usable data is present.
+ */
+export function computeRookieScore(inputs: RookieScoreInputs): number | null {
+  if (inputs.yearsExp !== null && inputs.yearsExp > 2) return null;
+
+  const norms = CFBD_NORMS[inputs.position];
+  if (!norms) return null;
+
+  const capMult = getCapitalMult(inputs.position, inputs.nflRound, inputs.yearsExp);
+  const capZ = capMultToZScale(capMult);
+  const fn = POSITION_FN[inputs.position];
+  if (!fn) return null;
+
+  return fn(capZ, norms, inputs.cfbd);
+}
+
+/**
+ * Batch-compute rookie scores, returning a map of playerId → score | null.
+ * Veterans (yearsExp > 2) are omitted from the map.
+ */
+export function buildRookieScoreMap(inputs: RookieScoreInputs[]): Map<string, number | null> {
+  const out = new Map<string, number | null>();
+  for (const inp of inputs) {
+    if (inp.yearsExp !== null && inp.yearsExp > 2) continue;
+    out.set(inp.playerId, computeRookieScore(inp));
+  }
+  return out;
+}

--- a/apps/draft-assistant/frontend/src/app/features/draft/utils/scheme-fit.util.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/utils/scheme-fit.util.spec.ts
@@ -1,0 +1,98 @@
+import {
+  computeSchemeFit,
+  buildSchemeFitMap,
+  schemeFitMult,
+  SchemeFitInputs,
+} from "./scheme-fit.util";
+
+function makeInputs(overrides: Partial<SchemeFitInputs> = {}): SchemeFitInputs {
+  return {
+    playerId: "p1",
+    position: "WR",
+    team: "KC",
+    aDot: null,
+    snapShare: null,
+    depthChartOrder: null,
+    ...overrides,
+  };
+}
+
+describe("computeSchemeFit", () => {
+  it("returns 0 for unknown team", () => {
+    expect(computeSchemeFit(makeInputs({ team: "XYZ" }))).toBe(0);
+  });
+
+  it("returns 0 for null team", () => {
+    expect(computeSchemeFit(makeInputs({ team: null }))).toBe(0);
+  });
+
+  it("returns a value in [-1, +1]", () => {
+    const teams = ["KC", "BUF", "MIA", "BAL", "TEN", "SF", "PIT", "CIN"];
+    const positions = ["WR", "RB", "TE", "QB"];
+    for (const team of teams) {
+      for (const position of positions) {
+        const score = computeSchemeFit(makeInputs({ team, position }));
+        expect(score).toBeGreaterThanOrEqual(-1);
+        expect(score).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  it("WR scores higher in elite pass-volume system (BUF) than in run-heavy system (TEN)", () => {
+    const wr_buf = computeSchemeFit(makeInputs({ team: "BUF", position: "WR" }));
+    const wr_ten = computeSchemeFit(makeInputs({ team: "TEN", position: "WR" }));
+    expect(wr_buf).toBeGreaterThan(wr_ten);
+  });
+
+  it("RB scores higher in run-heavy system (TEN) than in elite pass system (BUF)", () => {
+    const rb_ten = computeSchemeFit(makeInputs({ team: "TEN", position: "RB" }));
+    const rb_buf = computeSchemeFit(makeInputs({ team: "BUF", position: "RB" }));
+    expect(rb_ten).toBeGreaterThan(rb_buf);
+  });
+
+  it("deep-route WR (aDOT >= 12) fits high-concentration system better", () => {
+    // CIN has passConc: "high"; SF has passConc: "low"
+    const deep_cin = computeSchemeFit(makeInputs({ team: "CIN", position: "WR", aDot: 14 }));
+    const deep_sf = computeSchemeFit(makeInputs({ team: "SF", position: "WR", aDot: 14 }));
+    expect(deep_cin).toBeGreaterThan(deep_sf);
+  });
+
+  it("QB scores higher in hurry-up pass system (MIA) than in slow run-heavy (TEN)", () => {
+    const qb_mia = computeSchemeFit(makeInputs({ team: "MIA", position: "QB" }));
+    const qb_ten = computeSchemeFit(makeInputs({ team: "TEN", position: "QB" }));
+    expect(qb_mia).toBeGreaterThan(qb_ten);
+  });
+
+  it("is case-insensitive for team abbreviation", () => {
+    const upper = computeSchemeFit(makeInputs({ team: "KC" }));
+    const lower = computeSchemeFit(makeInputs({ team: "kc" }));
+    expect(upper).toBeCloseTo(lower, 10);
+  });
+});
+
+describe("schemeFitMult", () => {
+  it("returns 1.0 for neutral fit (0)", () => {
+    expect(schemeFitMult(0)).toBeCloseTo(1.0);
+  });
+
+  it("returns 1.1 for perfect fit (+1)", () => {
+    expect(schemeFitMult(1)).toBeCloseTo(1.1);
+  });
+
+  it("returns 0.9 for adverse fit (−1)", () => {
+    expect(schemeFitMult(-1)).toBeCloseTo(0.9);
+  });
+});
+
+describe("buildSchemeFitMap", () => {
+  it("returns a map entry for every input", () => {
+    const inputs: SchemeFitInputs[] = [
+      makeInputs({ playerId: "a", team: "KC" }),
+      makeInputs({ playerId: "b", team: "TEN", position: "RB" }),
+      makeInputs({ playerId: "c", team: null }),
+    ];
+    const map = buildSchemeFitMap(inputs);
+    expect(map.size).toBe(3);
+    expect(map.get("c")).toBe(0);
+  });
+});

--- a/apps/draft-assistant/frontend/src/app/features/draft/utils/scheme-fit.util.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/utils/scheme-fit.util.ts
@@ -1,0 +1,118 @@
+/**
+ * Scheme Fit — measures how well a player's archetype matches their
+ * team's offensive-coordinator tendencies.
+ *
+ * Returns a score in [−1, +1]. Applied in ContextMod as:
+ *   schemeFitMult = 1 + 0.10 × schemeFit
+ *
+ * Player archetype is inferred from NGS/PFR stats (when available) or
+ * falls back to positional heuristics. OC tendencies are hand-curated in
+ * oc-tendencies.ts and updated each offseason.
+ */
+
+import { OC_TENDENCIES, OcTendency, ProeBucket } from "../config/oc-tendencies";
+
+export interface SchemeFitInputs {
+  playerId: string;
+  position: string;
+  team: string | null;
+  /** Average Depth of Target (yards) from NGS — indicates route style. */
+  aDot: number | null;
+  /** Snap share 0–1 from nflverse rosters. */
+  snapShare: number | null;
+  /** Depth chart order (1 = starter). */
+  depthChartOrder: number | null;
+}
+
+// PROE bucket → pass-volume score (0–1).
+const PROE_VOLUME: Record<ProeBucket, number> = {
+  elite: 1.0,
+  high: 0.75,
+  avg: 0.5,
+  low: 0.25,
+  run_heavy: 0.0,
+};
+
+function scoreBucket(bucket: "high" | "avg" | "low"): number {
+  return bucket === "high" ? 1.0 : bucket === "avg" ? 0.5 : 0.0;
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+// Compute a per-position scheme-fit score in [0, 1].
+function positionalFit(pos: string, tendency: OcTendency, inputs: SchemeFitInputs): number {
+  const passVol = PROE_VOLUME[tendency.proe];
+  const p11 = scoreBucket(tendency.personnel11);
+  const motion = scoreBucket(tendency.motion);
+  const conc = scoreBucket(tendency.passConc);
+  const pace =
+    tendency.pace === "hurry_up"
+      ? 1.0
+      : tendency.pace === "fast"
+        ? 0.75
+        : tendency.pace === "avg"
+          ? 0.5
+          : 0.25;
+
+  switch (pos) {
+    case "WR": {
+      // WRs benefit from high pass vol, 11-personnel, high motion, fast pace.
+      // Deep routes (aDOT > 12) fit better in high-conc systems.
+      const depthFit =
+        inputs.aDot !== null ? (inputs.aDot >= 12 ? conc : (1 - conc) * 0.5 + 0.5) : 0.5;
+      return 0.35 * passVol + 0.25 * p11 + 0.2 * pace + 0.1 * motion + 0.1 * depthFit;
+    }
+    case "RB": {
+      // RBs hurt by high pass vol (fewer carries); benefit from multi-back
+      // or 21-personnel (low p11). Fast pace inflates volume.
+      return 0.4 * (1 - passVol) + 0.3 * (1 - p11) + 0.2 * pace + 0.1 * motion;
+    }
+    case "TE": {
+      // TEs benefit from low p11 (inline blocking / 12-personnel), low conc
+      // (targets distributed away from WR1), and high motion.
+      return 0.35 * (1 - p11) + 0.3 * passVol + 0.2 * (1 - conc) + 0.15 * motion;
+    }
+    case "QB": {
+      // QB benefits from fast pace, high pass vol, high motion (play-action).
+      return 0.4 * passVol + 0.3 * pace + 0.2 * p11 + 0.1 * motion;
+    }
+    default:
+      return 0.5;
+  }
+}
+
+/**
+ * Compute scheme fit for a single player.
+ *
+ * @returns Value in [−1, +1] where +1 = ideal fit, −1 = adverse fit, 0 = neutral.
+ *          Returns 0 when the team is unknown or not in the OC tendency table.
+ */
+export function computeSchemeFit(inputs: SchemeFitInputs): number {
+  if (!inputs.team) return 0;
+  const tendency = OC_TENDENCIES[inputs.team.toUpperCase()];
+  if (!tendency) return 0;
+
+  const rawFit = positionalFit(inputs.position, tendency, inputs);
+
+  // Map [0, 1] → [−1, +1] (0.5 → 0 = neutral).
+  const centered = (rawFit - 0.5) * 2;
+  return clamp(centered, -1, 1);
+}
+
+/**
+ * Batch-compute scheme fit, returning Map<playerId, schemeFit>.
+ */
+export function buildSchemeFitMap(inputs: SchemeFitInputs[]): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const inp of inputs) {
+    out.set(inp.playerId, computeSchemeFit(inp));
+  }
+  return out;
+}
+
+/** Convert schemeFit [−1, +1] to a ContextMod multiplier. */
+export function schemeFitMult(schemeFit: number): number {
+  return 1 + 0.1 * schemeFit;
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Two commits not yet in main after PR #69 was merged:

- **fix(player-card): restore mobile-friendly layout for narrow viewports**
  - Raises responsive breakpoint 480px → 640px to cover tablets and landscape phones
  - Restores 3-column card-header on ≤640px (avatar · name · actions), collapsing WCS badge column so player name doesn't overflow
  - Hides pills-row and explanation text on ≤640px
  - Adds `overflow:hidden` to `card-inner` to prevent child content escaping flex bounds

- **feat(draft): Phase 3 — board-state, rookie-score, scheme-fit + full 22 templates**

  **New utilities:**
  - `utils/board-state.util.ts` — `computeRunHeat` / `countRecentPositionPicks` extracted from `draft.store.ts` (tanh-clamped to [−0.1, +0.2])
  - `utils/rookie-score.util.ts` — capital + CFBD composite for `yearsExp ≤ 2`; position-specific formulas (WR/RB/TE/QB); falls back to capital-only when CFBD unavailable
  - `utils/scheme-fit.util.ts` — positional fit vs OC tendency profiles, returns [−1, +1]; `schemeFitMult = 1 + 0.10 × fit`
  - `config/oc-tendencies.ts` — 2026 season hand-curated PROE/pace/11-personnel/motion/passConc for all 32 teams

  **Explanation engine — all 22 templates now covered:**
  - #13 Scheme fit (fires at ±0.4 threshold)
  - #18 Early breakout age (≤19, rookie only)
  - #19 Elite athleticism / RAS (≥8.5/10)
  - #20 Vacated targets / landing spot (≥15% target share available)
  - Injury "Out/IR/PUP" magnitude bumped 20 → 21 to resolve tie-break with position-run

  **Model / wiring:**
  - `DraftPlayerRow` extended with Phase 3 stub fields (`rookieScore`, `schemeFit`, `dominatorRating`, `breakoutAge`, `ras`, `landingVacatedTargetPct`)
  - `player-normalization.service.ts` initialises all stubs to `null`
  - `draft.store.ts` delegates RunHeat to `board-state.util`, initialises Phase 3 row fields

  **Tests:** 223/223 passing (adds 37 new specs across board-state, rookie-score, scheme-fit)

## Test plan

- [ ] `npx tsc --noEmit` — clean compile
- [ ] `ng test` — 223/223 green
- [ ] Mobile (≤640px): player cards show name/WCS without horizontal overflow; pills row hidden
- [ ] Tablet/landscape (641–768px): pills row visible, no overflow
- [ ] Scheme-fit template fires for WR on KC/BUF (`🏟️ Scheme fit`) and is absent on TEN
- [ ] Age-cliff template (#11) still fires correctly for RB age 29+
- [ ] Injury "Out" template surfaces above position-run clause when maxClauses=1

https://claude.ai/code/session_01TnXL41fX1vecQxzXCaaij4
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnXL41fX1vecQxzXCaaij4)_