### PR TITLE
feat: highlight traded picks on draft board

### DIFF
--- a/apps/draft-assistant/frontend/src/app/core/adapters/sleeper/sleeper.service.ts
+++ b/apps/draft-assistant/frontend/src/app/core/adapters/sleeper/sleeper.service.ts
@@ -5,6 +5,7 @@ import {
   League,
   SleeperDraft,
   SleeperDraftPick,
+  SleeperTradedPick,
   LeagueRoster,
   LeagueUser,
   SleeperCatalogPlayer,
@@ -51,6 +52,10 @@ export class SleeperService {
 
   getDraftPicks(draftId: string): Observable<SleeperDraftPick[]> {
     return this.http.get<SleeperDraftPick[]>(`${BASE}/draft/${draftId}/picks`);
+  }
+
+  getTradedDraftPicks(draftId: string): Observable<SleeperTradedPick[]> {
+    return this.http.get<SleeperTradedPick[]>(`${BASE}/draft/${draftId}/traded_picks`);
   }
 
   getTrendingPlayers(

--- a/apps/draft-assistant/frontend/src/app/core/models/index.ts
+++ b/apps/draft-assistant/frontend/src/app/core/models/index.ts
@@ -74,6 +74,16 @@ export interface SleeperDraftPick {
   is_keeper?: boolean;
 }
 
+export interface SleeperTradedPick {
+  season: string;
+  round: number;
+  /** Original roster that owned this pick (draft slot owner). */
+  roster_id: number;
+  previous_owner_id: number;
+  /** Current holder of the pick after trades. */
+  owner_id: number;
+}
+
 export interface DraftPlayerRow {
   playerId: string;
   fullName: string;

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-board-grid/draft-board-grid.component.html
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-board-grid/draft-board-grid.component.html
@@ -43,6 +43,7 @@
       <span class="legend-item pos-te" role="listitem">TE</span>
       <span class="legend-item legend-current" role="listitem">On clock</span>
       <span class="legend-item legend-mine" role="listitem">My picks</span>
+      <span class="legend-item legend-traded" role="listitem">Traded</span>
     </div>
 
     <!-- Grid rows -->
@@ -54,6 +55,7 @@
             [class.cell-current]="cell.isCurrentPick"
             [class.cell-mine-empty]="cell.isMyTeam && !cell.pick && !cell.isCurrentPick"
             [class.cell-picked]="!!cell.pick"
+            [class.cell-traded]="cell.isTraded"
             [ngClass]="cell.pick ? positionClass(cell.position) : ''"
             [attr.aria-label]="
               cell.pick

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-board-grid/draft-board-grid.component.scss
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-board-grid/draft-board-grid.component.scss
@@ -92,6 +92,12 @@
   color: var(--primary, #4c22bd);
 }
 
+.legend-traded {
+  background: rgba(234, 88, 12, 0.08);
+  border: 1.5px solid #ea580c;
+  color: #c2410c;
+}
+
 // ── Grid rows ────────────────────────────────────────────────────────── //
 
 .board-row {
@@ -126,6 +132,12 @@
   &.cell-mine-empty {
     border: 2px solid var(--primary, #4c22bd);
     background: rgba(76, 34, 189, 0.04);
+  }
+
+  // Traded pick → orange accent border + subtle tint
+  &.cell-traded {
+    border-color: #ea580c;
+    box-shadow: inset 3px 0 0 #ea580c;
   }
 }
 
@@ -268,6 +280,12 @@ html.dark {
     color: #c4b5fd;
   }
 
+  .legend-traded {
+    background: rgba(234, 88, 12, 0.15);
+    border-color: #fb923c;
+    color: #fdba74;
+  }
+
   .board-cell {
     &.cell-current {
       background: rgba(59, 130, 246, 0.15) !important;
@@ -277,6 +295,11 @@ html.dark {
 
     &.cell-mine-empty {
       background: rgba(76, 34, 189, 0.12);
+    }
+
+    &.cell-traded {
+      border-color: #fb923c;
+      box-shadow: inset 3px 0 0 #fb923c;
     }
   }
 }

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-board-grid/draft-board-grid.component.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-board-grid/draft-board-grid.component.ts
@@ -1,6 +1,11 @@
 import { ChangeDetectionStrategy, Component, computed, input } from "@angular/core";
 import { NgClass, NgStyle } from "@angular/common";
-import { DraftPlayerRow, SleeperDraft, SleeperDraftPick } from "../../../core/models";
+import {
+  DraftPlayerRow,
+  SleeperDraft,
+  SleeperDraftPick,
+  SleeperTradedPick,
+} from "../../../core/models";
 import {
   GridCell,
   GridRow,
@@ -23,6 +28,7 @@ export type { GridCell, GridRow, GridTeamHeader };
 export class DraftBoardGridComponent {
   readonly draft = input.required<SleeperDraft>();
   readonly picks = input<SleeperDraftPick[]>([]);
+  readonly tradedPicks = input<SleeperTradedPick[]>([]);
   readonly rosterDisplayNames = input<Record<string, string>>({});
   readonly rosterAvatarIds = input<Record<string, string | null>>({});
   readonly playerNameMap = input<Record<string, string>>({});
@@ -69,6 +75,7 @@ export class DraftBoardGridComponent {
       this.playerNameMap(),
       this.tierByPlayerId(),
       this.currentUserId(),
+      this.tradedPicks(),
     ),
   );
 

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-board-grid/draft-board-grid.util.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-board-grid/draft-board-grid.util.spec.ts
@@ -6,7 +6,12 @@ import {
   mapRosterAvatarIds,
   pickInRoundFromPickNo,
 } from "./draft-board-grid.util";
-import { LeagueRoster, LeagueUser, SleeperDraftPick } from "../../../core/models";
+import {
+  LeagueRoster,
+  LeagueUser,
+  SleeperDraftPick,
+  SleeperTradedPick,
+} from "../../../core/models";
 
 describe("draft-board-grid.util", () => {
   // ------------------------------------------------------------------ //
@@ -229,6 +234,57 @@ describe("draft-board-grid.util", () => {
     it("returns empty when teams or rounds are 0", () => {
       const emptyDraft = { ...baseDraft, settings: { teams: 0, rounds: 0 } };
       expect(buildGridRows(emptyDraft, [], {}, new Map(), null)).toEqual([]);
+    });
+
+    // ---- isTraded ---- //
+
+    it("flags a cell as isTraded when the traded_picks endpoint includes its round + original roster", () => {
+      const tradedPick: SleeperTradedPick = {
+        season: "2024",
+        round: 1,
+        roster_id: 10, // original owner of slot 1
+        previous_owner_id: 10,
+        owner_id: 20, // now owned by team 2
+      };
+      const rows = buildGridRows(baseDraft, [], {}, new Map(), null, [tradedPick]);
+      // Slot 1 (rosterId 10) round 1 should be traded
+      expect(rows[0].cells[0].isTraded).toBeTrue();
+      // Slot 2 (rosterId 20) round 1 should not be traded
+      expect(rows[0].cells[1].isTraded).toBeFalse();
+    });
+
+    it("flags a drafted pick as isTraded when its roster_id differs from the original slot owner", () => {
+      // Slot 1 originally belongs to roster 10, but the pick was drafted by roster 20
+      const pick: SleeperDraftPick = {
+        pick_no: 1,
+        round: 1,
+        player_id: "p1",
+        roster_id: 20, // traded — now held by roster 20
+        draft_slot: 1,
+      };
+      const rows = buildGridRows(baseDraft, [pick], {}, new Map(), null, []);
+      expect(rows[0].cells[0].isTraded).toBeTrue();
+    });
+
+    it("does not flag a drafted pick as isTraded when roster_id matches the original slot owner", () => {
+      const pick: SleeperDraftPick = {
+        pick_no: 1,
+        round: 1,
+        player_id: "p1",
+        roster_id: 10, // same as slot 1 original owner — not traded
+        draft_slot: 1,
+      };
+      const rows = buildGridRows(baseDraft, [pick], {}, new Map(), null, []);
+      expect(rows[0].cells[0].isTraded).toBeFalse();
+    });
+
+    it("returns isTraded false for all cells when tradedPicks is empty", () => {
+      const rows = buildGridRows(baseDraft, [], {}, new Map(), null, []);
+      for (const row of rows) {
+        for (const cell of row.cells) {
+          expect(cell.isTraded).toBeFalse();
+        }
+      }
     });
   });
 

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-board-grid/draft-board-grid.util.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-board-grid/draft-board-grid.util.ts
@@ -1,4 +1,10 @@
-import { LeagueRoster, LeagueUser, SleeperDraft, SleeperDraftPick } from "../../../core/models";
+import {
+  LeagueRoster,
+  LeagueUser,
+  SleeperDraft,
+  SleeperDraftPick,
+  SleeperTradedPick,
+} from "../../../core/models";
 import { extractLastName } from "../../../core/utils/player-name.util";
 
 export interface GridTeamHeader {
@@ -27,6 +33,8 @@ export interface GridCell {
   overallTier: number | null;
   isCurrentPick: boolean;
   isMyTeam: boolean;
+  /** True when this pick has been traded away from its original draft slot owner. */
+  isTraded: boolean;
 }
 
 export interface GridRow {
@@ -116,10 +124,10 @@ export const buildGridHeaders = (
  *
  * @param draft               Sleeper draft metadata
  * @param picks               Normalized completed picks
- * @param rosterDisplayNames  roster_id → display name (unused here but kept for symmetry)
  * @param playerNameMap       player_id → full name
  * @param tierByPlayerId      player_id → overall tier (optional, pass empty map if unavailable)
  * @param currentUserId       logged-in user's Sleeper user_id
+ * @param tradedPicks         Traded picks from the Sleeper traded_picks endpoint
  */
 export const buildGridRows = (
   draft: SleeperDraft,
@@ -127,6 +135,7 @@ export const buildGridRows = (
   playerNameMap: Record<string, string>,
   tierByPlayerId: Map<string, number | null>,
   currentUserId: string | null,
+  tradedPicks: SleeperTradedPick[] = [],
 ): GridRow[] => {
   const teams = Number(draft.settings?.["teams"] ?? 0);
   const rounds = Number(draft.settings?.["rounds"] ?? 0);
@@ -145,6 +154,12 @@ export const buildGridRows = (
   const picksByNo = new Map<number, SleeperDraftPick>();
   for (const p of picks) {
     picksByNo.set(p.pick_no, p);
+  }
+
+  // Build a set of "round-originalRosterId" keys for picks that have been traded.
+  const tradedPickKeys = new Set<string>();
+  for (const tp of tradedPicks) {
+    tradedPickKeys.add(`${tp.round}-${tp.roster_id}`);
   }
 
   return Array.from({ length: rounds }, (_, ri) => {
@@ -171,6 +186,15 @@ export const buildGridRows = (
       const tier = playerId ? (tierByPlayerId.get(playerId) ?? null) : null;
       const pickLabel = formatPickLabel(round, pickNo, teams);
 
+      // A pick is traded if it appears in the traded_picks endpoint (keyed by round + original roster)
+      // or if the drafted pick's current roster differs from the original slot owner.
+      const isTraded =
+        (slotRosterId !== null && tradedPickKeys.has(`${round}-${slotRosterId}`)) ||
+        (draftedPick !== null &&
+          slotRosterId !== null &&
+          draftedPick.roster_id !== null &&
+          draftedPick.roster_id !== slotRosterId);
+
       return {
         pickNo,
         round,
@@ -184,6 +208,7 @@ export const buildGridRows = (
         overallTier: tier,
         isCurrentPick: pickNo === nextPickNo,
         isMyTeam: effectiveRosterId !== null && effectiveRosterId === myRosterId,
+        isTraded,
       };
     });
 

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft.component.html
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft.component.html
@@ -73,6 +73,7 @@
         <app-draft-board-grid
           [draft]="selectedDraft"
           [picks]="store.picks()"
+          [tradedPicks]="store.tradedPicks()"
           [rosterDisplayNames]="store.rosterDisplayNames()"
           [rosterAvatarIds]="store.rosterAvatarIds()"
           [playerNameMap]="store.playerNameMap()"

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
@@ -1395,7 +1395,7 @@ export const DraftStore = signalStore(
             forkJoin([
               sleeper.getDraft(selectedDraftId),
               sleeper.getDraftPicks(selectedDraftId),
-              sleeper.getTradedDraftPicks(selectedDraftId),
+              sleeper.getTradedDraftPicks(selectedDraftId).pipe(catchError(() => of([]))),
             ]),
           );
 
@@ -1469,7 +1469,7 @@ export const DraftStore = signalStore(
               forkJoin([
                 sleeper.getDraft(selectedDraftId),
                 sleeper.getDraftPicks(selectedDraftId),
-                sleeper.getTradedDraftPicks(selectedDraftId),
+                sleeper.getTradedDraftPicks(selectedDraftId).pipe(catchError(() => of([]))),
               ]),
             );
             selectedDraft = draftDetail;
@@ -1572,7 +1572,7 @@ export const DraftStore = signalStore(
               forkJoin([
                 sleeper.getDraft(draftId),
                 sleeper.getDraftPicks(draftId),
-                sleeper.getTradedDraftPicks(draftId),
+                sleeper.getTradedDraftPicks(draftId).pipe(catchError(() => of([]))),
               ]),
             );
             const context = await loadDraftContext(draft, fallbackLeagueId);

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
@@ -19,6 +19,7 @@ import {
   LeagueUser,
   SleeperDraft,
   SleeperDraftPick,
+  SleeperTradedPick,
   TierSource,
 } from "../../core/models";
 import { mapRosterAvatarIds } from "./draft-board-grid/draft-board-grid.util";
@@ -111,6 +112,7 @@ interface DraftState {
   rosterAvatarIds: Record<string, string | null>;
   playerNameMap: Record<string, string>;
   picks: SleeperDraftPick[];
+  tradedPicks: SleeperTradedPick[];
   rows: DraftPlayerRow[];
   selectedPositions: DraftPositionFilter[];
   rookiesOnly: boolean;
@@ -210,6 +212,7 @@ export const DraftStore = signalStore(
     rosterAvatarIds: {},
     playerNameMap: {},
     picks: [],
+    tradedPicks: [] as SleeperTradedPick[],
     rows: [],
     selectedPositions: DEFAULT_POSITIONS,
     rookiesOnly: false,
@@ -1388,8 +1391,12 @@ export const DraftStore = signalStore(
               .map((pick) => pick.player_id),
           );
 
-          const [draft, picks] = await firstValueFrom(
-            forkJoin([sleeper.getDraft(selectedDraftId), sleeper.getDraftPicks(selectedDraftId)]),
+          const [draft, picks, tradedPicks] = await firstValueFrom(
+            forkJoin([
+              sleeper.getDraft(selectedDraftId),
+              sleeper.getDraftPicks(selectedDraftId),
+              sleeper.getTradedDraftPicks(selectedDraftId),
+            ]),
           );
 
           const normalizedPicks = normalizePicks(draft, picks);
@@ -1402,6 +1409,7 @@ export const DraftStore = signalStore(
             draftStatus: draft.status ?? null,
             drafts: upsertDraft(store.drafts(), draft),
             picks: normalizedPicks,
+            tradedPicks,
             staleData: false,
             lastUpdatedAt: Date.now(),
             error: null,
@@ -1425,6 +1433,7 @@ export const DraftStore = signalStore(
           staleData: false,
           selectedLeagueId: leagueId,
           picks: [],
+          tradedPicks: [],
         });
 
         try {
@@ -1453,14 +1462,20 @@ export const DraftStore = signalStore(
 
           let selectedDraft: SleeperDraft | null = null;
           let picks: SleeperDraftPick[] = [];
+          let tradedPicks: SleeperTradedPick[] = [];
           let nextDrafts = drafts;
           if (selectedDraftId) {
-            const [draftDetail, draftPicks] = await firstValueFrom(
-              forkJoin([sleeper.getDraft(selectedDraftId), sleeper.getDraftPicks(selectedDraftId)]),
+            const [draftDetail, draftPicks, draftTradedPicks] = await firstValueFrom(
+              forkJoin([
+                sleeper.getDraft(selectedDraftId),
+                sleeper.getDraftPicks(selectedDraftId),
+                sleeper.getTradedDraftPicks(selectedDraftId),
+              ]),
             );
             selectedDraft = draftDetail;
             nextDrafts = upsertDraft(drafts, draftDetail);
             picks = normalizePicks(draftDetail, draftPicks);
+            tradedPicks = draftTradedPicks;
           }
 
           const isRookieDraft = selectedDraft ? isSleeperRookieDraft(selectedDraft) : false;
@@ -1488,6 +1503,7 @@ export const DraftStore = signalStore(
             rosterAvatarIds,
             rows,
             picks,
+            tradedPicks,
             rookiesOnly: isRookieDraft,
             starredPlayerIds,
             sortSource: loadSortSource(leagueId),
@@ -1523,6 +1539,7 @@ export const DraftStore = signalStore(
           rosterDisplayNames: {},
           rosterAvatarIds: {},
           picks: [],
+          tradedPicks: [],
           rows: [],
           starredPlayerIds: [],
           lastUpdatedAt: null,
@@ -1551,8 +1568,12 @@ export const DraftStore = signalStore(
           });
 
           try {
-            const [draft, picks] = await firstValueFrom(
-              forkJoin([sleeper.getDraft(draftId), sleeper.getDraftPicks(draftId)]),
+            const [draft, picks, tradedPicks] = await firstValueFrom(
+              forkJoin([
+                sleeper.getDraft(draftId),
+                sleeper.getDraftPicks(draftId),
+                sleeper.getTradedDraftPicks(draftId),
+              ]),
             );
             const context = await loadDraftContext(draft, fallbackLeagueId);
 
@@ -1569,6 +1590,7 @@ export const DraftStore = signalStore(
               drafts: nextDrafts,
               draftStatus: draft.status ?? null,
               picks: normalizePicks(draft, picks),
+              tradedPicks,
               rookiesOnly: options?.rookieHint === true ? true : isSleeperRookieDraft(draft),
               starredPlayerIds: context.starredPlayerIds,
               staleData: false,
@@ -1663,6 +1685,7 @@ export const DraftStore = signalStore(
             selectedDraftId: null,
             draftStatus: null,
             picks: [],
+            tradedPicks: [],
             rows: [],
             starredPlayerIds: [],
             sortSource: "combinedTier",


### PR DESCRIPTION
## Summary

- Fetches traded picks from `GET /v1/draft/<id>/traded_picks` alongside regular picks in all three load paths (`loadForLeague`, `selectDraft`, `refreshDraft`)
- Adds `SleeperTradedPick` model and `getTradedDraftPicks()` to `SleeperService`
- Extends `GridCell` with an `isTraded` boolean; `buildGridRows` builds a `round-originalRosterId` lookup set from the traded picks array and marks each affected cell
- Highlights traded cells with an orange left-border accent (`cell-traded` CSS class) in both light and dark mode, plus a "Traded" legend entry on the board

## Test plan

- [ ] Load a draft with known traded picks — cells whose original slot owner traded away the pick should show an orange left border
- [ ] Verify un-traded picks have no orange border
- [ ] Verify already-drafted traded picks are also highlighted (uses `draftedPick.roster_id !== slotRosterId` fallback)
- [ ] Check "Traded" appears in the position legend below the team headers
- [ ] Verify dark mode renders the orange accent correctly
- [ ] Confirm the build passes: `pnpm run build:ci`

https://claude.ai/code/session_01AsQvxVNMvN5BfypN5mt6g2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsQvxVNMvN5BfypN5mt6g2)_