### PR TITLE
feat: weekly improve-codebase-architecture schedule

### DIFF
--- a/.claude/install-weekly-timer.sh
+++ b/.claude/install-weekly-timer.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Installs the weekly arch-review systemd user timer for this checkout.
+# Run once after cloning; safe to re-run.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+USER_SYSTEMD="$HOME/.config/systemd/user"
+
+mkdir -p "$USER_SYSTEMD"
+
+cat > "$USER_SYSTEMD/arch-review.service" << EOF
+[Unit]
+Description=Weekly improve-codebase-architecture skill run
+
+[Service]
+Type=oneshot
+ExecStart=$SCRIPT_DIR/weekly-arch-review.sh
+EOF
+
+cat > "$USER_SYSTEMD/arch-review.timer" << EOF
+[Unit]
+Description=Run architecture review every Monday at 09:00
+
+[Timer]
+OnCalendar=Mon *-*-* 09:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+
+systemctl --user daemon-reload
+systemctl --user enable --now arch-review.timer
+
+echo "Timer installed. Next runs:"
+systemctl --user list-timers arch-review.timer

--- a/.claude/weekly-arch-review.sh
+++ b/.claude/weekly-arch-review.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Runs the improve-codebase-architecture skill weekly via cron.
+# Output is logged to ~/.claude/logs/arch-review.log
+
+set -euo pipefail
+
+LOG_DIR="$HOME/.claude/logs"
+LOG_FILE="$LOG_DIR/arch-review.log"
+
+mkdir -p "$LOG_DIR"
+
+echo "=== Architecture review started: $(date) ===" >> "$LOG_FILE"
+
+cd /home/user/FF-DA
+
+/opt/node22/bin/claude \
+  --print "/improve-codebase-architecture" \
+  >> "$LOG_FILE" 2>&1
+
+echo "=== Architecture review finished: $(date) ===" >> "$LOG_FILE"

--- a/.claude/weekly-arch-review.sh
+++ b/.claude/weekly-arch-review.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
-# Runs the improve-codebase-architecture skill weekly via cron.
+# Runs the improve-codebase-architecture skill weekly via systemd timer.
 # Output is logged to ~/.claude/logs/arch-review.log
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 LOG_DIR="$HOME/.claude/logs"
 LOG_FILE="$LOG_DIR/arch-review.log"
 
@@ -11,9 +13,9 @@ mkdir -p "$LOG_DIR"
 
 echo "=== Architecture review started: $(date) ===" >> "$LOG_FILE"
 
-cd /home/user/FF-DA
+cd "$REPO_ROOT"
 
-/opt/node22/bin/claude \
+claude \
   --print "/improve-codebase-architecture" \
   >> "$LOG_FILE" 2>&1
 


### PR DESCRIPTION
## Summary

- Adds `.claude/weekly-arch-review.sh` — runs the `improve-codebase-architecture` skill via `claude --print` every Monday at 09:00, logging output to `~/.claude/logs/arch-review.log`
- Adds systemd user timer/service units (`~/.config/systemd/user/arch-review.{timer,service}`) to trigger the script on schedule

## Activating on your machine

After pulling, run once to enable the timer:

```bash
systemctl --user daemon-reload
systemctl --user enable --now arch-review.timer
# Verify
systemctl --user list-timers arch-review.timer
```

To run it immediately for a test:

```bash
systemctl --user start arch-review.service
tail -f ~/.claude/logs/arch-review.log
```

## Test plan

- [ ] Pull branch and run `systemctl --user daemon-reload && systemctl --user enable --now arch-review.timer`
- [ ] Confirm `systemctl --user list-timers` shows next trigger as Monday 09:00
- [ ] Run `systemctl --user start arch-review.service` manually and verify log output in `~/.claude/logs/arch-review.log`

https://claude.ai/code/session_01QoXCNdnw4APyxJc1kqVspm

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoXCNdnw4APyxJc1kqVspm)_