### PR TITLE
fix: bake baseHref into angular.json to fix Pages artifacts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
         run: pnpm install
 
       - name: Build project
-        run: pnpm draft-assistant:build:ci --base-href /FF-DA/
+        run: pnpm draft-assistant:build:ci
 
       - name: Verify Pages artifact contents
         run: |

--- a/apps/draft-assistant/frontend/angular.json
+++ b/apps/draft-assistant/frontend/angular.json
@@ -53,7 +53,8 @@
                   "maximumError": "20kB"
                 }
               ],
-              "outputHashing": "all"
+              "outputHashing": "all",
+              "baseHref": "/FF-DA/"
             },
             "development": {
               "optimization": false,


### PR DESCRIPTION
## Summary

- Adds `"baseHref": "/FF-DA/"` to the `production` configuration in `angular.json`
- Removes `--base-href /FF-DA/` extra arg from `deploy.yml`'s build step

## Why Pages was showing the README

The deploy workflow has gone through several iterations that each had an issue:

| Commit | Problem |
|---|---|
| `684dc20` | `configure-pages` lacked `enablement: true` → Pages source never switched to GitHub Actions |
| `528c406` | Added `enablement: true` but kept `lint`/`fmt:check` steps — if either failed on any push, the build was skipped and no artifact was deployed |
| PR #79 | Switched to `angular-cli-ghpages` but required a manual Pages source change (to `gh-pages` branch) that was never made |
| `cbb9d00` | Reverted to native approach and removed lint/format steps (good), but left `--base-href /FF-DA/` being threaded through a 3-level pnpm workspace filter script chain |

The last step — `pnpm draft-assistant:build:ci --base-href /FF-DA/` — relies on pnpm forwarding `--base-href` through a nested workspace filter call (`pnpm --filter @ff/draft-assistant-frontend run build:ci`), which is fragile. If `--base-href` is not forwarded, Angular uses the default `/` base href and the app deploys with broken asset paths, causing the artifact to appear empty/broken, which GitHub Pages falls back on by serving the main-branch README.

## Fix

Moving `baseHref` into `angular.json`'s production configuration is the canonical Angular approach — it's reliably applied regardless of how the build is invoked.

## Test plan

- [ ] Merge to main and confirm the deploy workflow completes the `Deploy GitHub Pages` job without error
- [ ] Visit `https://Feyb.github.io/FF-DA/` and confirm the Angular app loads (not the README)

https://claude.ai/code/session_01KjcG6YxLbVtdm63GvsbVFi

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjcG6YxLbVtdm63GvsbVFi)_