### PR TITLE
fix: exclude llms.txt from deploy trigger to prevent bot cancellations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'llms.txt'
+      - 'ingest-response.json'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Root cause

The deploy workflow has **never actually completed**. Every human push triggers:

1. The deploy workflow starts
2. `update-llms.yml` runs, refreshes llms.txt, and pushes a bot commit ~5 minutes later
3. The bot commit triggers a **new** deploy workflow run, which cancels the in-progress one (`cancel-in-progress: true`)
4. The bot-triggered deploy runs instead — but it too gets cancelled next time

You can see this pattern in the git log — every real commit is immediately followed by a `chore: refresh llms.txt` commit.

## Fix

Add `paths-ignore` to the deploy workflow trigger so `llms.txt` and `ingest-response.json` changes (bot-only files) don't trigger (or cancel) the deploy:

```yaml
on:
  push:
    branches:
      - main
    paths-ignore:
      - 'llms.txt'
      - 'ingest-response.json'
```

This mirrors the same pattern already in `update-llms.yml` (`paths-ignore: llms.txt`) which prevents recursive bot triggers.

## Test plan

- [ ] Merge this PR
- [ ] Confirm the deploy workflow runs to completion (not cancelled by the subsequent llms.txt refresh)
- [ ] Visit `https://Feyb.github.io/FF-DA/` and confirm the Angular app loads

https://claude.ai/code/session_01KjcG6YxLbVtdm63GvsbVFi

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjcG6YxLbVtdm63GvsbVFi)_