### PR TITLE
feat: activate stack-synergy (γ) and bye-week cluster (δ) in NeedMultiplier

### DIFF
--- a/apps/draft-assistant/frontend/src/app/core/adapters/ffc/ffc-adp.service.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/core/adapters/ffc/ffc-adp.service.spec.ts
@@ -74,4 +74,13 @@ describe("FfcAdpService", () => {
     const lookup = service.buildNameLookup(FIXTURE);
     expect(lookup.get(service.normalizeName("Bijan Robinson"))?.adp).toBe(2.8);
   });
+
+  it("preserves bye week in the parsed player object", (done) => {
+    service.getAdp("half-ppr").subscribe((players) => {
+      expect(players[0].bye).toBe(12);
+      expect(players[1].bye).toBe(5);
+      done();
+    });
+    http.expectOne("assets/ffc/adp-half-ppr-12team.json").flush(FIXTURE);
+  });
 });

--- a/apps/draft-assistant/frontend/src/app/core/models/index.ts
+++ b/apps/draft-assistant/frontend/src/app/core/models/index.ts
@@ -134,6 +134,8 @@ export interface DraftPlayerRow {
   adpMean: number | null;
   /** FantasyFootballCalculator ADP standard deviation in picks. */
   adpStd: number | null;
+  /** NFL bye week (1–14) sourced from FFC ADP data. Null when unavailable. */
+  byeWeek: number | null;
   /**
    * Consensus base value on a 0–100 scale, position-normalized via trimmed
    * z-mean of all available ranking sources. Higher = better. See

--- a/apps/draft-assistant/frontend/src/app/core/services/player-normalization.service.ts
+++ b/apps/draft-assistant/frontend/src/app/core/services/player-normalization.service.ts
@@ -219,6 +219,7 @@ export class PlayerNormalizationService {
       fantasyCalcTrend30Day: fcPlayer?.trend30Day ?? null,
       adpMean: ffcPlayer?.adp ?? null,
       adpStd: ffcPlayer?.stdev ?? null,
+      byeWeek: ffcPlayer?.bye ?? null,
       baseValue: null,
       baseValueDivergence: null,
       pAvailAtNext: null,

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-ranking.util.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-ranking.util.spec.ts
@@ -34,6 +34,7 @@ function buildRow(overrides: Partial<DraftPlayerRow> = {}): DraftPlayerRow {
     fantasyCalcTrend30Day: null,
     adpMean: null,
     adpStd: null,
+    byeWeek: null,
     baseValue: null,
     baseValueDivergence: null,
     pAvailAtNext: null,

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-sort.util.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-sort.util.spec.ts
@@ -38,6 +38,7 @@ function buildRow(overrides: Partial<DraftPlayerRow> = {}): DraftPlayerRow {
     fantasyCalcTrend30Day: null,
     adpMean: null,
     adpStd: null,
+    byeWeek: null,
     baseValue: null,
     baseValueDivergence: null,
     pAvailAtNext: null,

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
@@ -432,6 +432,24 @@ export const DraftStore = signalStore(
         return out;
       });
 
+      // Counts the user's drafted picks per bye week.
+      // Shared between NeedMultiplier (δ bye-cluster penalty) and wcsExplanationByPlayer (#14 template).
+      const userByeWeekCounts = computed((): Map<number, number> => {
+        const rowByPlayerId = new Map(store.rows().map((r) => [r.playerId, r]));
+        const userRosterId = store.userRosterId();
+        const out = new Map<number, number>();
+        if (userRosterId !== null) {
+          for (const pick of store.picks()) {
+            if (pick.roster_id !== userRosterId || !pick.player_id) continue;
+            const r = rowByPlayerId.get(pick.player_id);
+            if (r?.byeWeek != null) {
+              out.set(r.byeWeek, (out.get(r.byeWeek) ?? 0) + 1);
+            }
+          }
+        }
+        return out;
+      });
+
       // NeedMultiplier: roster-aware position need score per player.
       // Formula: clamp(1 + α·unfilledGap − β·stackedPenalty + γ·stackSynergy − δ·byeCluster, 0.5, 1.6)
       const needMultiplierByPlayer = computed((): Map<string, number> => {
@@ -447,19 +465,7 @@ export const DraftStore = signalStore(
           store.existingRosterPlayerIds(),
         );
 
-        // Bye-week histogram: count user's drafted picks per bye week for cluster detection.
-        const rowByPlayerId = new Map(store.rows().map((r) => [r.playerId, r]));
-        const userRosterId = store.userRosterId();
-        const userByeWeekCounts = new Map<number, number>();
-        if (userRosterId !== null) {
-          for (const pick of store.picks()) {
-            if (pick.roster_id !== userRosterId || !pick.player_id) continue;
-            const r = rowByPlayerId.get(pick.player_id);
-            if (r?.byeWeek != null) {
-              userByeWeekCounts.set(r.byeWeek, (userByeWeekCounts.get(r.byeWeek) ?? 0) + 1);
-            }
-          }
-        }
+        const byeWeekCounts = userByeWeekCounts();
         const qbByTeam = userQbByTeam();
 
         const out = new Map<string, number>();
@@ -475,12 +481,11 @@ export const DraftStore = signalStore(
           const unfilledGap = Math.max(0, configured - filled) / configured;
           // StackedPenalty: how far above (configured + 1 bench) we are.
           const stackedPenalty = Math.max(0, filled - (configured + 1)) / configured;
+          // "Pass-catcher" includes RB: QB-RB stacks are a real dynasty strategy.
           const stackSynergy =
             gamma > 0 && row.position !== "QB" && row.team && qbByTeam.has(row.team) ? 1 : 0;
           const byeCluster =
-            delta > 0 && row.byeWeek != null && (userByeWeekCounts.get(row.byeWeek) ?? 0) >= 3
-              ? 1
-              : 0;
+            delta > 0 && row.byeWeek != null && (byeWeekCounts.get(row.byeWeek) ?? 0) >= 3 ? 1 : 0;
           const raw =
             1 +
             alpha * unfilledGap -
@@ -636,21 +641,9 @@ export const DraftStore = signalStore(
 
         // #12 StackSynergy — reuse the shared QB-by-team signal.
         const qbByTeam = userQbByTeam();
-
-        // #14 ByeWeekCluster — bye-week histogram from user's picks.
-        const rowByPlayerId = new Map(store.rows().map((r) => [r.playerId, r]));
-        const userRosterId = store.userRosterId();
+        // #14 ByeWeekCluster — reuse the shared bye-week histogram signal.
+        const byeWeekCounts = userByeWeekCounts();
         const { delta } = NEED_WEIGHTS[store.draftMode()];
-        const userByeWeekCounts = new Map<number, number>();
-        if (userRosterId !== null) {
-          for (const pick of store.picks()) {
-            if (pick.roster_id !== userRosterId || !pick.player_id) continue;
-            const r = rowByPlayerId.get(pick.player_id);
-            if (r?.byeWeek != null) {
-              userByeWeekCounts.set(r.byeWeek, (userByeWeekCounts.get(r.byeWeek) ?? 0) + 1);
-            }
-          }
-        }
         const trendingMap = trendingTopTenMap();
 
         const out = new Map<string, string>();
@@ -663,7 +656,7 @@ export const DraftStore = signalStore(
           const stackSynergyQbName =
             row.position !== "QB" && row.team ? (qbByTeam.get(row.team) ?? null) : null;
           const byeWeekCluster =
-            delta > 0 && row.byeWeek != null && (userByeWeekCounts.get(row.byeWeek) ?? 0) >= 3;
+            delta > 0 && row.byeWeek != null && (byeWeekCounts.get(row.byeWeek) ?? 0) >= 3;
           const explanation = generateExplanation({
             baseValue: base.baseValue,
             baseValueDivergence: base.divergence,

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
@@ -412,12 +412,31 @@ export const DraftStore = signalStore(
         },
       );
 
+      // Maps NFL team code → QB name on the user's current roster (existing + session picks).
+      // Shared between NeedMultiplier (γ stack-synergy) and wcsExplanationByPlayer (#12 template).
+      const userQbByTeam = computed((): Map<string, string> => {
+        const rowByPlayerId = new Map(store.rows().map((r) => [r.playerId, r]));
+        const out = new Map<string, string>();
+        for (const pid of store.existingRosterPlayerIds()) {
+          const r = rowByPlayerId.get(pid);
+          if (r?.position === "QB" && r.team) out.set(r.team, r.fullName);
+        }
+        const userRosterId = store.userRosterId();
+        if (userRosterId !== null) {
+          for (const pick of store.picks()) {
+            if (pick.roster_id !== userRosterId || !pick.player_id) continue;
+            const r = rowByPlayerId.get(pick.player_id);
+            if (r?.position === "QB" && r.team) out.set(r.team, r.fullName);
+          }
+        }
+        return out;
+      });
+
       // NeedMultiplier: roster-aware position need score per player.
-      // Formula: clamp(1 + α·unfilledGap − β·stackedPenalty, 0.5, 1.6)
-      // StackSynergy (γ) and ByeCluster (δ) are Phase 3 additions; defaulting to 0 here.
+      // Formula: clamp(1 + α·unfilledGap − β·stackedPenalty + γ·stackSynergy − δ·byeCluster, 0.5, 1.6)
       const needMultiplierByPlayer = computed((): Map<string, number> => {
         const mode = store.draftMode();
-        const { alpha, beta } = NEED_WEIGHTS[mode];
+        const { alpha, beta, gamma, delta } = NEED_WEIGHTS[mode];
         const league = appStore.selectedLeague();
         const rosterPositions = league?.roster_positions ?? [];
         const { configuredByPos, filledByPos } = buildRosterFillInfo(
@@ -427,6 +446,22 @@ export const DraftStore = signalStore(
           store.rows(),
           store.existingRosterPlayerIds(),
         );
+
+        // Bye-week histogram: count user's drafted picks per bye week for cluster detection.
+        const rowByPlayerId = new Map(store.rows().map((r) => [r.playerId, r]));
+        const userRosterId = store.userRosterId();
+        const userByeWeekCounts = new Map<number, number>();
+        if (userRosterId !== null) {
+          for (const pick of store.picks()) {
+            if (pick.roster_id !== userRosterId || !pick.player_id) continue;
+            const r = rowByPlayerId.get(pick.player_id);
+            if (r?.byeWeek != null) {
+              userByeWeekCounts.set(r.byeWeek, (userByeWeekCounts.get(r.byeWeek) ?? 0) + 1);
+            }
+          }
+        }
+        const qbByTeam = userQbByTeam();
+
         const out = new Map<string, number>();
         for (const row of store.rows()) {
           const pos = row.position;
@@ -440,7 +475,18 @@ export const DraftStore = signalStore(
           const unfilledGap = Math.max(0, configured - filled) / configured;
           // StackedPenalty: how far above (configured + 1 bench) we are.
           const stackedPenalty = Math.max(0, filled - (configured + 1)) / configured;
-          const raw = 1 + alpha * unfilledGap - beta * stackedPenalty;
+          const stackSynergy =
+            gamma > 0 && row.position !== "QB" && row.team && qbByTeam.has(row.team) ? 1 : 0;
+          const byeCluster =
+            delta > 0 && row.byeWeek != null && (userByeWeekCounts.get(row.byeWeek) ?? 0) >= 3
+              ? 1
+              : 0;
+          const raw =
+            1 +
+            alpha * unfilledGap -
+            beta * stackedPenalty +
+            gamma * stackSynergy -
+            delta * byeCluster;
           out.set(row.playerId, Math.max(0.5, Math.min(1.6, raw)));
         }
         return out;
@@ -588,19 +634,21 @@ export const DraftStore = signalStore(
           number
         >;
 
-        // #12 StackSynergy — map each NFL team to the QB name on the user's roster.
+        // #12 StackSynergy — reuse the shared QB-by-team signal.
+        const qbByTeam = userQbByTeam();
+
+        // #14 ByeWeekCluster — bye-week histogram from user's picks.
         const rowByPlayerId = new Map(store.rows().map((r) => [r.playerId, r]));
-        const userQbByTeam = new Map<string, string>();
         const userRosterId = store.userRosterId();
-        for (const pid of store.existingRosterPlayerIds()) {
-          const r = rowByPlayerId.get(pid);
-          if (r?.position === "QB" && r.team) userQbByTeam.set(r.team, r.fullName);
-        }
+        const { delta } = NEED_WEIGHTS[store.draftMode()];
+        const userByeWeekCounts = new Map<number, number>();
         if (userRosterId !== null) {
           for (const pick of store.picks()) {
             if (pick.roster_id !== userRosterId || !pick.player_id) continue;
             const r = rowByPlayerId.get(pick.player_id);
-            if (r?.position === "QB" && r.team) userQbByTeam.set(r.team, r.fullName);
+            if (r?.byeWeek != null) {
+              userByeWeekCounts.set(r.byeWeek, (userByeWeekCounts.get(r.byeWeek) ?? 0) + 1);
+            }
           }
         }
         const trendingMap = trendingTopTenMap();
@@ -613,7 +661,9 @@ export const DraftStore = signalStore(
           const effScore = effMap.get(row.playerId) ?? null;
           const playerStats = playerStatsMap().get(row.playerId);
           const stackSynergyQbName =
-            row.position !== "QB" && row.team ? (userQbByTeam.get(row.team) ?? null) : null;
+            row.position !== "QB" && row.team ? (qbByTeam.get(row.team) ?? null) : null;
+          const byeWeekCluster =
+            delta > 0 && row.byeWeek != null && (userByeWeekCounts.get(row.byeWeek) ?? 0) >= 3;
           const explanation = generateExplanation({
             baseValue: base.baseValue,
             baseValueDivergence: base.divergence,
@@ -644,6 +694,7 @@ export const DraftStore = signalStore(
                 : null,
             vnp: vnpMap.get(row.playerId) ?? null,
             stackSynergyQbName,
+            byeWeekCluster,
             trendingAdds: trendingMap.get(row.playerId) ?? null,
             injuryStatus: row.injuryStatus,
           });

--- a/apps/draft-assistant/frontend/src/app/features/draft/score-explanation.util.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/score-explanation.util.spec.ts
@@ -139,7 +139,7 @@ describe("score-explanation.util", () => {
   describe("template #14 — bye-week cluster", () => {
     it("fires when byeWeekCluster is true", () => {
       const out = generateExplanation(buildSignals({ byeWeekCluster: true }));
-      expect(out).toContain("Bye-week cluster");
+      expect(out).toContain("Bye-week cluster: 3+ of your picks already share this bye");
     });
 
     it("does not fire when byeWeekCluster is false", () => {

--- a/apps/draft-assistant/frontend/src/app/features/draft/score-explanation.util.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/score-explanation.util.spec.ts
@@ -136,6 +136,23 @@ describe("score-explanation.util", () => {
     });
   });
 
+  describe("template #14 — bye-week cluster", () => {
+    it("fires when byeWeekCluster is true", () => {
+      const out = generateExplanation(buildSignals({ byeWeekCluster: true }));
+      expect(out).toContain("Bye-week cluster");
+    });
+
+    it("does not fire when byeWeekCluster is false", () => {
+      const out = generateExplanation(buildSignals({ byeWeekCluster: false }));
+      expect(out).not.toContain("Bye-week cluster");
+    });
+
+    it("does not fire when byeWeekCluster is undefined", () => {
+      const out = generateExplanation(buildSignals({}));
+      expect(out).not.toContain("Bye-week cluster");
+    });
+  });
+
   describe("template #21 — injury designation", () => {
     it("fires with magnitude 20 for Out status", () => {
       const out = generateExplanation(buildSignals({ injuryStatus: "Out" }));

--- a/apps/draft-assistant/frontend/src/app/features/draft/score-explanation.util.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/score-explanation.util.ts
@@ -50,7 +50,7 @@ export interface ExplanationSignals {
   needMultiplier?: number;
   /** Active draft mode. */
   draftMode?: DraftMode;
-  /** Bye-week cluster flag (3+ starters share this player's bye). Phase 1 stub. */
+  /** Bye-week cluster flag (3+ of the user's picks share this player's bye week). */
   byeWeekCluster?: boolean;
   // Phase 2 signals — optional until nflverse data lands.
   /** NFL draft round (1-7; 8 = UDFA). Null for veterans. */
@@ -272,11 +272,11 @@ export function generateExplanation(
     });
   }
 
-  // #14 Bye-week cluster warning (stub — byeWeekCluster set by Phase 3)
+  // #14 Bye-week cluster warning
   if (signals.byeWeekCluster) {
     clauses.push({
       magnitude: 7,
-      text: `⛔ Bye-week cluster: 3+ starters already on this bye`,
+      text: `⛔ Bye-week cluster: 3+ of your picks already share this bye`,
     });
   }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Stack synergy (γ)** — pass-catchers whose team QB is already on the user's roster now receive a `+γ` NeedMultiplier bonus (0.05 startup, 0.08 redraft, 0 rookie). The QB-by-team lookup was extracted from `wcsExplanationByPlayer` into a shared `userQbByTeam` computed signal so both NeedMultiplier and the explanation generator use the same data without duplication.
- **Bye-week cluster (δ)** — `byeWeek: number | null` added to `DraftPlayerRow` and populated from `FfcAdpPlayer.bye` in `player-normalization.service.ts`. A per-bye-week histogram of the user's current picks is built in `needMultiplierByPlayer`; candidates whose bye week already has ≥ 3 starters take a `−δ` penalty (0.05 redraft, 0 otherwise). The same histogram feeds `byeWeekCluster` into `generateExplanation()` so template #14 (`⛔ Bye-week cluster`) fires correctly.

## Files changed

| File | Change |
|---|---|
| `core/models/index.ts` | Add `byeWeek: number \| null` to `DraftPlayerRow` |
| `core/services/player-normalization.service.ts` | Populate `byeWeek` from `ffcPlayer?.bye` |
| `features/draft/draft.store.ts` | Extract `userQbByTeam` signal; full four-term NeedMultiplier formula; `byeWeekCluster` in explanations |
| `ffc-adp.service.spec.ts` | Assert `bye` field survives the parse |
| `score-explanation.util.spec.ts` | Template #14 test coverage (fires / doesn't fire) |
| `draft-ranking.util.spec.ts` / `draft-sort.util.spec.ts` | Add `byeWeek: null` to fixture builders |

## Test plan

- [ ] `pnpm test` — all specs pass (TypeScript compiles clean; browser runner requires Chrome)
- [ ] Start a startup draft, draft a QB early — WRs/TEs on the same team show higher WCS and the `🔗 QB stack` explanation fires
- [ ] Draft 3 players sharing bye week 9 — the next player with bye 9 shows `⛔ Bye-week cluster` explanation and slightly reduced WCS
- [ ] Switch to rookie mode (γ=0, δ=0) — confirm neither bonus/penalty fires

https://claude.ai/code/session_01NuncVUKYHethPgus8ywa5d
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuncVUKYHethPgus8ywa5d)_