### PR TITLE
Add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,50 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm run draft-assistant:build:ci
+
+      - run: touch apps/draft-assistant/frontend/dist/browser/.nojekyll
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/draft-assistant/frontend/dist/browser
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- New `.github/workflows/deploy-pages.yml` builds `@ff/draft-assistant-frontend` and publishes it to GitHub Pages on every push to `main` (also runnable via `workflow_dispatch`).
- Uses the official `actions/configure-pages` + `upload-pages-artifact` + `deploy-pages` flow (no `gh-pages` branch needed).
- Builds via `pnpm draft-assistant:build:ci` so the deploy doesn't depend on the rankings sync scripts; production `baseHref=/FF-DA/` is already set in `angular.json`.
- Adds a `.nojekyll` to the published bundle. The existing `src/404.html` SPA-redirect shim is preserved as-is.

## Notes for enabling
- In repo Settings → Pages, set **Source** to *GitHub Actions*.

## Test plan
- [ ] Merge to `main` and confirm the `Deploy to GitHub Pages` workflow succeeds.
- [ ] Visit the published URL and verify the app loads at `/FF-DA/`.
- [ ] Hard-refresh a deep link (e.g. `/FF-DA/some/route`) and confirm the SPA 404 redirect restores the route.

https://claude.ai/code/session_01DwXC2xR7Z1YKR8ay7Hduc3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwXC2xR7Z1YKR8ay7Hduc3)_