### PR TITLE
Force Pages workflow JS actions onto Node 24

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -14,6 +14,9 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` at the workflow level so the JS actions in `deploy-pages.yml` (`actions/checkout`, `actions/setup-node`, `actions/configure-pages`, `actions/upload-pages-artifact`, `actions/deploy-pages`, `pnpm/action-setup`) run on Node.js 24, silencing the deprecation warning.
- Node 20 becomes non-default June 2, 2026 and is removed September 16, 2026; opting in now is forward-compatible since the latest pinned major versions of these actions already support Node 24.

## Test plan
- [ ] Workflow run on `main` after merge no longer emits the Node 20 deprecation notice.
- [ ] Pages deploy still succeeds and the published site loads.

https://claude.ai/code/session_01DwXC2xR7Z1YKR8ay7Hduc3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwXC2xR7Z1YKR8ay7Hduc3)_