### PR TITLE
refactor(theme): replace hardcoded colors with semantic CSS vars

### DIFF
--- a/apps/draft-assistant/frontend/src/app/features/draft/best-available-card/best-available-card.component.scss
+++ b/apps/draft-assistant/frontend/src/app/features/draft/best-available-card/best-available-card.component.scss
@@ -19,7 +19,7 @@
 
 .section-hint {
   font-size: 0.75rem;
-  color: rgb(100 116 139);
+  color: var(--text-faint);
   flex: 1 0 auto;
   text-align: right;
 }
@@ -36,15 +36,15 @@
   grid-template-columns: 4px auto 1fr auto;
   align-items: center;
   gap: 0.625rem;
-  border: 1px solid var(--tier-card-border, rgb(226 232 240));
+  border: 1px solid var(--tier-card-border, var(--border-subtle));
   border-radius: 0.5rem;
   padding: 0.5rem 0.625rem 0.5rem 0;
-  background: var(--tier-card-bg, #fff);
+  background: var(--tier-card-bg, var(--surface-container-lowest));
 
   &.ba-entry--clickable {
     cursor: pointer;
     &:hover {
-      background: var(--mat-sys-surface-variant, #f8fafc);
+      background: var(--mat-sys-surface-variant, var(--surface-container-high));
     }
   }
   overflow: hidden;
@@ -56,20 +56,20 @@
   width: 4px;
   align-self: stretch;
   border-radius: 0 0.25rem 0.25rem 0;
-  background: rgb(203 213 225);
+  background: var(--border-default);
   flex-shrink: 0;
 
   &--qb {
-    background: rgb(239 68 68);
+    background: var(--pos-qb);
   }
   &--rb {
-    background: rgb(34 197 94);
+    background: var(--pos-rb);
   }
   &--wr {
-    background: rgb(59 130 246);
+    background: var(--pos-wr);
   }
   &--te {
-    background: rgb(249 115 22);
+    background: var(--pos-te);
   }
 }
 
@@ -79,7 +79,7 @@
   height: 2.75rem;
   border-radius: 50%;
   object-fit: cover;
-  background: rgb(226 232 240);
+  background: var(--border-subtle);
   flex-shrink: 0;
 }
 
@@ -107,6 +107,7 @@
   text-overflow: ellipsis;
   flex: 1 1 auto;
   min-width: 0;
+  color: var(--on-surface);
 }
 
 .ba-pills {
@@ -120,7 +121,7 @@
   display: inline-flex;
   flex-direction: column;
   align-items: center;
-  background: rgb(241 245 249);
+  background: var(--surface-muted);
   border-radius: 0.3rem;
   padding: 0.0625rem 0.375rem;
   min-width: 2rem;
@@ -129,7 +130,7 @@
 .ba-pill-label {
   font-size: 0.55rem;
   font-weight: 600;
-  color: rgb(100 116 139);
+  color: var(--text-faint);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   line-height: 1.2;
@@ -138,40 +139,40 @@
 .ba-pill-val {
   font-size: 0.7rem;
   font-weight: 700;
-  color: rgb(30 41 59);
+  color: var(--text-heading);
   line-height: 1.2;
   white-space: nowrap;
 }
 
 .ba-eff-pill {
   &.eff-high {
-    background: rgb(187 247 208);
+    background: var(--success-bold-bg);
 
     .ba-pill-label,
     .ba-pill-val {
-      color: rgb(22 101 52);
+      color: var(--success-strong);
     }
   }
 
   &.eff-mid {
-    background: rgb(254 249 195);
+    background: var(--caution-bg);
 
     .ba-pill-label,
     .ba-pill-val {
-      color: rgb(113 63 18);
+      color: var(--caution-fg);
     }
   }
 
   &.eff-neutral {
-    background: rgb(241 245 249);
+    background: var(--surface-muted);
   }
 
   &.eff-low {
-    background: rgb(254 226 226);
+    background: var(--danger-bg);
 
     .ba-pill-label,
     .ba-pill-val {
-      color: rgb(153 27 27);
+      color: var(--danger-fg);
     }
   }
 }
@@ -179,19 +180,19 @@
 .ba-meta-chip {
   font-size: 0.6875rem;
   font-weight: 500;
-  color: rgb(100 116 139);
+  color: var(--text-faint);
   white-space: nowrap;
 }
 
 .ba-team {
   font-weight: 600;
-  color: rgb(71 85 105);
+  color: var(--text-muted);
 }
 
 .ba-empty {
   grid-column: 2 / -1;
   font-size: 0.8125rem;
-  color: rgb(148 163 184);
+  color: var(--text-disabled);
 }
 
 // ── Position badge ────────────────────────────────────────────────────────────
@@ -204,24 +205,24 @@
   border-radius: 0.25rem;
   padding: 0.0625rem 0.3125rem;
   flex-shrink: 0;
-  background: rgb(226 232 240);
-  color: rgb(51 65 85);
+  background: var(--border-subtle);
+  color: var(--text-secondary);
 
   &--qb {
-    background: rgb(254 226 226);
-    color: rgb(185 28 28);
+    background: var(--pos-qb-bg);
+    color: var(--pos-qb-fg);
   }
   &--rb {
-    background: rgb(220 252 231);
-    color: rgb(22 101 52);
+    background: var(--pos-rb-bg);
+    color: var(--pos-rb-fg);
   }
   &--wr {
-    background: rgb(219 234 254);
-    color: rgb(29 78 216);
+    background: var(--pos-wr-bg);
+    color: var(--pos-wr-fg);
   }
   &--te {
-    background: rgb(255 237 213);
-    color: rgb(154 52 18);
+    background: var(--pos-te-bg);
+    color: var(--pos-te-fg);
   }
 }
 
@@ -234,13 +235,13 @@
 }
 
 .adp-value {
-  color: rgb(22 163 74);
+  color: var(--success);
 }
 .adp-reach {
-  color: rgb(220 38 38);
+  color: var(--danger);
 }
 .adp-neutral {
-  color: rgb(100 116 139);
+  color: var(--text-faint);
 }
 
 // ── Right column ──────────────────────────────────────────────────────────────
@@ -258,20 +259,20 @@
   padding: 0.1875rem 0.5rem;
   border-radius: 0.375rem;
   white-space: nowrap;
-  background: rgb(226 232 240);
-  color: rgb(51 65 85);
+  background: var(--border-subtle);
+  color: var(--text-secondary);
 
   &.wcs-high {
-    background: rgb(187 247 208);
-    color: rgb(22 101 52);
+    background: var(--success-bold-bg);
+    color: var(--success-strong);
   }
   &.wcs-mid {
-    background: rgb(254 249 195);
-    color: rgb(113 63 18);
+    background: var(--caution-bg);
+    color: var(--caution-fg);
   }
   &.wcs-low {
-    background: rgb(241 245 249);
-    color: rgb(100 116 139);
+    background: var(--surface-muted);
+    color: var(--text-faint);
   }
 }
 
@@ -283,8 +284,8 @@
   padding: 0.0625rem 0.3125rem;
   border-radius: 0.25rem;
   white-space: nowrap;
-  background: rgb(219 234 254);
-  color: rgb(29 78 216);
+  background: var(--info-bg);
+  color: var(--info-fg);
   text-transform: uppercase;
 }
 
@@ -296,148 +297,10 @@
   white-space: nowrap;
 
   &.at-risk {
-    background: rgb(254 226 226);
-    color: rgb(153 27 27);
+    background: var(--danger-bg);
+    color: var(--danger-fg);
   }
 }
 
-// ── Dark mode ─────────────────────────────────────────────────────────────────
-html.dark {
-  .section-header h2 {
-    color: rgb(226 232 240);
-  }
-
-  .best-available-entry {
-    border-color: var(--tier-card-border, rgb(51 65 85));
-    background: var(--tier-card-bg, rgb(15 13 19));
-  }
-
-  .pos-accent {
-    background: rgb(51 65 85);
-  }
-
-  .ba-avatar {
-    background: rgb(51 65 85);
-  }
-
-  .ba-name {
-    color: rgb(226 232 240);
-  }
-
-  .ba-pill {
-    background: rgb(30 41 59);
-  }
-
-  .ba-pill-label {
-    color: rgb(71 85 105);
-  }
-
-  .ba-pill-val {
-    color: rgb(148 163 184);
-  }
-
-  .ba-eff-pill {
-    &.eff-high {
-      background: rgb(6 78 59);
-
-      .ba-pill-label,
-      .ba-pill-val {
-        color: rgb(110 231 183);
-      }
-    }
-
-    &.eff-mid {
-      background: rgb(66 32 6);
-
-      .ba-pill-label,
-      .ba-pill-val {
-        color: rgb(252 211 77);
-      }
-    }
-
-    &.eff-neutral {
-      background: rgb(30 41 59);
-    }
-
-    &.eff-low {
-      background: rgb(127 29 29);
-
-      .ba-pill-label,
-      .ba-pill-val {
-        color: rgb(252 165 165);
-      }
-    }
-  }
-
-  .ba-meta-chip {
-    color: rgb(71 85 105);
-  }
-
-  .ba-team {
-    color: rgb(100 116 139);
-  }
-
-  .ba-empty {
-    color: rgb(71 85 105);
-  }
-
-  .pos-badge {
-    background: rgb(51 65 85);
-    color: rgb(148 163 184);
-
-    &--qb {
-      background: rgb(127 29 29);
-      color: rgb(252 165 165);
-    }
-    &--rb {
-      background: rgb(20 83 45);
-      color: rgb(134 239 172);
-    }
-    &--wr {
-      background: rgb(30 58 138);
-      color: rgb(147 197 253);
-    }
-    &--te {
-      background: rgb(67 20 7);
-      color: rgb(253 186 116);
-    }
-  }
-
-  .wcs-badge {
-    background: rgb(30 41 59);
-    color: rgb(148 163 184);
-
-    &.wcs-high {
-      background: rgb(6 78 59);
-      color: rgb(110 231 183);
-    }
-    &.wcs-mid {
-      background: rgb(66 32 6);
-      color: rgb(252 211 77);
-    }
-    &.wcs-low {
-      background: rgb(15 23 42);
-      color: rgb(71 85 105);
-    }
-  }
-
-  .availability-badge.at-risk {
-    background: rgb(127 29 29);
-    color: rgb(252 165 165);
-  }
-
-  .mc-badge {
-    background: rgb(30 58 138);
-    color: rgb(147 197 253);
-  }
-
-  .adp-value {
-    color: rgb(74 222 128);
-  }
-  .adp-reach {
-    color: rgb(252 165 165);
-  }
-  .adp-neutral {
-    color: rgb(100 116 139);
-  }
-}
+// All color states are sourced from theme variables which automatically
+// swap between light and dark — no html.dark block needed.

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-board-grid/draft-board-grid.component.scss
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-board-grid/draft-board-grid.component.scss
@@ -34,8 +34,8 @@
   min-width: 0;
 
   &.header-mine {
-    background: rgba(76, 34, 189, 0.08);
-    box-shadow: inset 0 -3px 0 var(--primary, #4c22bd);
+    background: color-mix(in srgb, var(--primary) 8%, transparent);
+    box-shadow: inset 0 -3px 0 var(--primary);
   }
 }
 
@@ -45,11 +45,11 @@
   border-radius: 50%;
   object-fit: cover;
   flex-shrink: 0;
-  background: #e2e8f0;
+  background: var(--border-subtle);
   border: 2px solid transparent;
 
   .header-mine & {
-    border-color: var(--primary, #4c22bd);
+    border-color: var(--primary);
   }
 }
 
@@ -81,21 +81,21 @@
 }
 
 .legend-current {
-  background: rgba(37, 99, 235, 0.14);
-  border: 1.5px solid #2563eb;
-  color: #1d4ed8;
+  background: color-mix(in srgb, var(--info-border-strong) 14%, transparent);
+  border: 1.5px solid var(--info-border-strong);
+  color: var(--info-strong);
 }
 
 .legend-mine {
-  background: rgba(76, 34, 189, 0.07);
-  border: 1.5px solid var(--primary, #4c22bd);
-  color: var(--primary, #4c22bd);
+  background: color-mix(in srgb, var(--primary) 7%, transparent);
+  border: 1.5px solid var(--primary);
+  color: var(--primary-on-active);
 }
 
 .legend-traded {
-  background: rgba(234, 88, 12, 0.08);
-  border: 1.5px solid #ea580c;
-  color: #c2410c;
+  background: color-mix(in srgb, var(--warning-border) 16%, transparent);
+  border: 1.5px solid var(--warning-border);
+  color: var(--warning-fg);
 }
 
 // ── Grid rows ────────────────────────────────────────────────────────── //
@@ -123,21 +123,21 @@
 
   // Current pick → strong blue glow
   &.cell-current {
-    background: rgba(37, 99, 235, 0.1) !important;
-    box-shadow: 0 0 0 2px #2563eb;
-    border-color: #2563eb;
+    background: color-mix(in srgb, var(--info-border-strong) 10%, transparent) !important;
+    box-shadow: 0 0 0 2px var(--info-border-strong);
+    border-color: var(--info-border-strong);
   }
 
   // My upcoming empty picks → subtle brand outline
   &.cell-mine-empty {
-    border: 2px solid var(--primary, #4c22bd);
-    background: rgba(76, 34, 189, 0.04);
+    border: 2px solid var(--primary);
+    background: color-mix(in srgb, var(--primary) 6%, transparent);
   }
 
   // Traded pick → orange accent border + subtle tint
   &.cell-traded {
-    border-color: #ea580c;
-    box-shadow: inset 3px 0 0 #ea580c;
+    border-color: var(--warning-border);
+    box-shadow: inset 3px 0 0 var(--warning-border);
   }
 }
 
@@ -262,47 +262,9 @@
   }
 }
 
-// ── Dark-mode overrides ──────────────────────────────────────────────── //
-
-html.dark {
-  .header-avatar {
-    background: rgb(51 65 85);
-  }
-
-  .legend-current {
-    background: rgba(37, 99, 235, 0.2);
-    border-color: #3b82f6;
-    color: #93c5fd;
-  }
-
-  .legend-mine {
-    background: rgba(76, 34, 189, 0.15);
-    color: #c4b5fd;
-  }
-
-  .legend-traded {
-    background: rgba(234, 88, 12, 0.15);
-    border-color: #fb923c;
-    color: #fdba74;
-  }
-
-  .board-cell {
-    &.cell-current {
-      background: rgba(59, 130, 246, 0.15) !important;
-      box-shadow: 0 0 0 2px #3b82f6;
-      border-color: #3b82f6;
-    }
-
-    &.cell-mine-empty {
-      background: rgba(76, 34, 189, 0.12);
-    }
-
-    &.cell-traded {
-      border-color: #fb923c;
-      box-shadow: inset 3px 0 0 #fb923c;
-    }
-  }
-}
+// Dark-mode appearance is driven entirely by themed CSS variables
+// (--info-*, --primary, --warning-*, --border-subtle, --primary-on-active),
+// so no explicit html.dark overrides are needed here.
 
 // ── Responsive ──────────────────────────────────────────────────────── //
 

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-controls-card/draft-controls-card.component.scss
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-controls-card/draft-controls-card.component.scss
@@ -14,7 +14,7 @@
 .source-switch-label {
   font-size: 0.8125rem;
   font-weight: 600;
-  color: rgb(71 85 105);
+  color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -57,12 +57,12 @@
 .mock-draft-error {
   margin-top: 0.25rem;
   font-size: 0.8125rem;
-  color: rgb(185 28 28);
+  color: var(--danger-strong);
 }
 
 .updated-at {
   font-size: 0.8125rem;
-  color: rgb(71 85 105);
+  color: var(--text-muted);
 }
 
 .draft-option-content {
@@ -85,7 +85,7 @@
 
 .draft-option-title {
   font-weight: 600;
-  color: rgb(15 23 42);
+  color: var(--on-surface);
 }
 
 .draft-option-status {
@@ -98,29 +98,29 @@
   letter-spacing: 0.04em;
   text-transform: uppercase;
   white-space: nowrap;
-  background: rgb(226 232 240);
-  color: rgb(51 65 85);
+  background: var(--border-subtle);
+  color: var(--text-secondary);
 }
 
 .draft-option-status-drafting {
-  background: rgb(220 252 231);
-  color: rgb(22 101 52);
+  background: var(--success-soft-bg);
+  color: var(--success-strong);
 }
 
 .draft-option-status-pre-draft,
 .draft-option-status-scheduled {
-  background: rgb(254 249 195);
-  color: rgb(133 77 14);
+  background: var(--caution-bg);
+  color: var(--caution-fg-strong);
 }
 
 .draft-option-status-complete {
-  background: rgb(226 232 240);
-  color: rgb(71 85 105);
+  background: var(--surface-muted);
+  color: var(--text-muted);
 }
 
 .draft-option-status-direct {
-  background: rgb(219 234 254);
-  color: rgb(30 64 175);
+  background: var(--info-bg);
+  color: var(--info-strong);
 }
 
 .draft-option-meta-row {
@@ -131,15 +131,15 @@
 
 .draft-option-meta-pill {
   border-radius: 9999px;
-  background: rgb(241 245 249);
+  background: var(--surface-muted);
   padding: 0.125rem 0.5rem;
   font-size: 0.75rem;
-  color: rgb(51 65 85);
+  color: var(--text-secondary);
 }
 
 .draft-option-subtitle {
   font-size: 0.75rem;
-  color: rgb(100 116 139);
+  color: var(--text-faint);
 }
 
 @media (max-width: 720px) {
@@ -152,51 +152,5 @@
   }
 }
 
-html.dark {
-  .source-switch-label {
-    color: rgb(148 163 184);
-  }
-
-  .updated-at {
-    color: rgb(148 163 184);
-  }
-
-  .draft-option-title {
-    color: rgb(226 232 240);
-  }
-
-  .draft-option-status {
-    background: rgb(51 65 85);
-    color: rgb(203 213 225);
-  }
-
-  .draft-option-status-drafting {
-    background: rgb(6 78 59);
-    color: rgb(110 231 183);
-  }
-
-  .draft-option-status-pre-draft,
-  .draft-option-status-scheduled {
-    background: rgb(66 32 6);
-    color: rgb(253 211 77);
-  }
-
-  .draft-option-status-complete {
-    background: rgb(30 41 59);
-    color: rgb(148 163 184);
-  }
-
-  .draft-option-status-direct {
-    background: rgb(23 37 84);
-    color: rgb(147 197 253);
-  }
-
-  .draft-option-meta-pill {
-    background: rgb(30 41 59);
-    color: rgb(148 163 184);
-  }
-
-  .mock-draft-error {
-    color: rgb(252 165 165);
-  }
-}
+// All status, label, and pill colors come from theme variables and swap
+// automatically between light and dark mode — no html.dark block needed.

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-player-list/draft-player-list.component.scss
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-player-list/draft-player-list.component.scss
@@ -19,7 +19,7 @@
 
 .section-hint {
   font-size: 0.75rem;
-  color: rgb(100 116 139);
+  color: var(--text-faint);
   flex: 1 0 auto;
   text-align: right;
 }
@@ -50,14 +50,14 @@
   margin-top: 0.75rem;
   margin-bottom: 0.5rem;
   padding: 0.5rem 0.75rem;
-  border-top: 2px solid rgb(59 130 246);
-  border-bottom: 1px solid rgb(191 219 254);
-  background: rgb(239 246 255);
+  border-top: 2px solid var(--info-border);
+  border-bottom: 1px solid color-mix(in srgb, var(--info-border) 35%, transparent);
+  background: var(--info-bg-soft);
   font-size: 0.75rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: rgb(30 64 175);
+  color: var(--info-strong);
 }
 
 .next-pick-divider-label {
@@ -74,24 +74,7 @@
 .tier-divider-label {
   font-size: 0.75rem;
   font-weight: 700;
-  color: rgb(51 65 85);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.04em;
-}
-
-html.dark {
-  .section-header h2 {
-    color: rgb(226 232 240);
-  }
-
-  .next-pick-divider-row {
-    background: rgb(23 37 84);
-    border-top-color: #3b82f6;
-    border-bottom-color: rgba(59, 130, 246, 0.3);
-    color: rgb(147 197 253);
-  }
-
-  .tier-divider-label {
-    color: rgb(148 163 184);
-  }
 }

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-sidebar/draft-sidebar.component.scss
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-sidebar/draft-sidebar.component.scss
@@ -20,7 +20,7 @@
 
 .summary-title {
   font-size: 0.875rem;
-  color: rgb(71 85 105);
+  color: var(--text-muted);
   margin-bottom: 0.75rem;
 }
 
@@ -32,7 +32,7 @@
 
 .summary-label {
   font-size: 0.75rem;
-  color: rgb(100 116 139);
+  color: var(--text-faint);
 }
 
 .summary-value {
@@ -63,7 +63,7 @@
 
 .section-hint {
   font-size: 0.75rem;
-  color: rgb(100 116 139);
+  color: var(--text-faint);
   flex: 1 0 auto;
   text-align: right;
 }
@@ -86,7 +86,7 @@
   align-items: center;
   gap: 0.625rem;
   padding: 0.25rem 0;
-  border-bottom: 1px solid rgb(241 245 249);
+  border-bottom: 1px solid var(--border-subtle);
 
   &.need-filled {
     opacity: 0.55;
@@ -97,7 +97,7 @@
   font-size: 0.75rem;
   font-weight: 700;
   min-width: 2.5rem;
-  color: rgb(71 85 105);
+  color: var(--text-muted);
   text-transform: uppercase;
 }
 
@@ -111,21 +111,21 @@
   width: 0.625rem;
   height: 0.625rem;
   border-radius: 50%;
-  background: rgb(226 232 240);
+  background: var(--border-subtle);
 
   &.filled {
-    background: rgb(99 102 241);
+    background: var(--primary);
   }
 }
 
 .need-label {
   font-size: 0.75rem;
-  color: rgb(100 116 139);
+  color: var(--text-faint);
   min-width: 2.5rem;
   text-align: right;
 
   &.need-complete {
-    color: rgb(22 163 74);
+    color: var(--success);
   }
 }
 
@@ -133,7 +133,7 @@
   font-size: 1rem;
   height: 1rem;
   width: 1rem;
-  color: rgb(22 163 74);
+  color: var(--success);
 }
 
 .roster-list {
@@ -148,17 +148,21 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.25rem 0;
-  border-bottom: 1px solid rgb(241 245 249);
+  border-bottom: 1px solid var(--border-subtle);
   font-size: 0.8125rem;
 
   &.roster-row--clickable {
     cursor: pointer;
     &:hover {
-      background: var(--mat-sys-surface-variant, #f8fafc);
+      background: var(--mat-sys-surface-variant, var(--surface-container-high));
     }
   }
 }
 
+// NOTE: This sidebar's position badges use a different palette from the
+// app-wide --pos-{qb,rb,wr,te}-bg/fg tokens (e.g. QB renders blue here, not
+// red). Kept as-is intentionally; if these should align with the global
+// position palette, swap for the --pos-* tokens.
 .roster-pos-badge {
   font-size: 0.7rem;
   font-weight: 700;
@@ -169,20 +173,20 @@
   text-transform: uppercase;
 
   &.pos-qb {
-    background: rgb(219 234 254);
-    color: rgb(30 64 175);
+    background: var(--pos-wr-bg);
+    color: var(--pos-wr-fg);
   }
   &.pos-rb {
-    background: rgb(220 252 231);
-    color: rgb(22 101 52);
+    background: var(--pos-rb-bg);
+    color: var(--pos-rb-fg);
   }
   &.pos-wr {
-    background: rgb(253 230 138);
-    color: rgb(120 53 15);
+    background: var(--caution-bg);
+    color: var(--warning-fg-strong);
   }
   &.pos-te {
-    background: rgb(252 231 243);
-    color: rgb(136 19 55);
+    background: var(--pos-te-bg);
+    color: var(--pos-te-fg);
   }
 }
 
@@ -196,7 +200,7 @@
 
 .roster-tier {
   font-size: 0.75rem;
-  color: rgb(100 116 139);
+  color: var(--text-faint);
   white-space: nowrap;
 }
 
@@ -207,50 +211,11 @@
 }
 
 .adp-value {
-  color: rgb(22 163 74);
+  color: var(--success);
 }
 .adp-reach {
-  color: rgb(220 38 38);
+  color: var(--danger);
 }
 .adp-neutral {
-  color: rgb(100 116 139);
-}
-
-html.dark {
-  .section-header h2 {
-    color: rgb(226 232 240);
-  }
-
-  .need-dot {
-    background: rgb(51 65 85);
-  }
-  .need-dot.filled {
-    background: rgb(129 140 248);
-  }
-  .need-row {
-    border-bottom-color: rgb(30 41 59);
-  }
-  .need-pos {
-    color: rgb(148 163 184);
-  }
-  .need-label {
-    color: rgb(100 116 139);
-  }
-
-  .roster-row {
-    border-bottom-color: rgb(30 41 59);
-  }
-  .roster-tier {
-    color: rgb(100 116 139);
-  }
-
-  .adp-value {
-    color: rgb(74 222 128);
-  }
-  .adp-reach {
-    color: rgb(252 165 165);
-  }
-  .adp-neutral {
-    color: rgb(100 116 139);
-  }
+  color: var(--text-faint);
 }

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-sidebar/draft-sidebar.component.scss
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-sidebar/draft-sidebar.component.scss
@@ -159,10 +159,16 @@
   }
 }
 
-// NOTE: This sidebar's position badges use a different palette from the
-// app-wide --pos-{qb,rb,wr,te}-bg/fg tokens (e.g. QB renders blue here, not
-// red). Kept as-is intentionally; if these should align with the global
-// position palette, swap for the --pos-* tokens.
+// NOTE: this sidebar's roster badges intentionally do NOT match the app-wide
+// position palette. They preserve the original sidebar look by remapping each
+// position to a different theme token:
+//   QB → --pos-wr-bg/fg   (renders blue, not the QB red used elsewhere)
+//   RB → --pos-rb-bg/fg   (green — same as elsewhere)
+//   WR → --caution-bg / --warning-fg-strong  (yellow, not the WR blue)
+//   TE → --pos-te-bg/fg   (orange; original was a bespoke pink that has no
+//                          theme token, so this is a small visual change)
+// To make this view consistent with the global position palette, swap each
+// branch for the matching --pos-{qb,rb,wr,te}-bg/fg pair.
 .roster-pos-badge {
   font-size: 0.7rem;
   font-weight: 700;

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-strategy-curve/draft-strategy-curve.component.scss
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-strategy-curve/draft-strategy-curve.component.scss
@@ -19,24 +19,24 @@
   border-radius: 0.2rem;
   padding: 0.0625rem 0.25rem;
   text-align: center;
-  background: rgb(226 232 240);
-  color: rgb(51 65 85);
+  background: var(--border-subtle);
+  color: var(--text-secondary);
 
   &--qb {
-    background: rgb(254 226 226);
-    color: rgb(185 28 28);
+    background: var(--pos-qb-bg);
+    color: var(--pos-qb-fg);
   }
   &--rb {
-    background: rgb(220 252 231);
-    color: rgb(22 101 52);
+    background: var(--pos-rb-bg);
+    color: var(--pos-rb-fg);
   }
   &--wr {
-    background: rgb(219 234 254);
-    color: rgb(29 78 216);
+    background: var(--pos-wr-bg);
+    color: var(--pos-wr-fg);
   }
   &--te {
-    background: rgb(255 237 213);
-    color: rgb(154 52 18);
+    background: var(--pos-te-bg);
+    color: var(--pos-te-fg);
   }
 }
 
@@ -45,14 +45,14 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  color: rgb(30 41 59);
+  color: var(--text-heading);
   min-width: 0;
 }
 
 .sc-bar-wrap {
   width: 3rem;
   height: 0.375rem;
-  background: rgb(241 245 249);
+  background: var(--surface-muted);
   border-radius: 999px;
   overflow: hidden;
   flex-shrink: 0;
@@ -61,27 +61,27 @@
 .sc-bar {
   height: 100%;
   border-radius: 999px;
-  background: rgb(148 163 184);
+  background: var(--text-disabled);
   transition: width 0.3s ease;
 
   &--qb {
-    background: rgb(239 68 68);
+    background: var(--pos-qb);
   }
   &--rb {
-    background: rgb(34 197 94);
+    background: var(--pos-rb);
   }
   &--wr {
-    background: rgb(59 130 246);
+    background: var(--pos-wr);
   }
   &--te {
-    background: rgb(249 115 22);
+    background: var(--pos-te);
   }
 }
 
 .sc-wcs {
   font-size: 0.65rem;
   font-weight: 700;
-  color: rgb(71 85 105);
+  color: var(--text-muted);
   min-width: 1.5rem;
   text-align: right;
   flex-shrink: 0;
@@ -90,49 +90,8 @@
 .sc-mc {
   font-size: 0.6rem;
   font-weight: 700;
-  color: rgb(29 78 216);
+  color: var(--info-fg);
   min-width: 1.75rem;
   text-align: right;
   flex-shrink: 0;
-}
-
-// ── Dark mode ─────────────────────────────────────────────────────────────────
-html.dark {
-  .sc-pos {
-    background: rgb(51 65 85);
-    color: rgb(148 163 184);
-
-    &--qb {
-      background: rgb(127 29 29);
-      color: rgb(252 165 165);
-    }
-    &--rb {
-      background: rgb(20 83 45);
-      color: rgb(134 239 172);
-    }
-    &--wr {
-      background: rgb(30 58 138);
-      color: rgb(147 197 253);
-    }
-    &--te {
-      background: rgb(67 20 7);
-      color: rgb(253 186 116);
-    }
-  }
-
-  .sc-name {
-    color: rgb(203 213 225);
-  }
-
-  .sc-bar-wrap {
-    background: rgb(30 41 59);
-  }
-
-  .sc-wcs {
-    color: rgb(100 116 139);
-  }
-
-  .sc-mc {
-    color: rgb(147 197 253);
-  }
 }

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft-tier-alerts/draft-tier-alerts.component.scss
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft-tier-alerts/draft-tier-alerts.component.scss
@@ -3,16 +3,16 @@
   align-items: center;
   gap: 0.625rem;
   padding: 0.625rem 0.875rem;
-  background: rgb(255 237 213);
-  border: 1px solid rgb(251 191 36);
+  background: var(--warning-bg);
+  border: 1px solid var(--warning-border-strong);
   border-radius: 0.375rem;
   font-size: 0.875rem;
   font-weight: 600;
-  color: rgb(120 53 15);
+  color: var(--warning-fg-strong);
   animation: slideIn 0.25s ease;
 
   mat-icon {
-    color: rgb(217 119 6);
+    color: var(--warning);
     flex-shrink: 0;
   }
 
@@ -25,7 +25,7 @@
   background: none;
   border: none;
   cursor: pointer;
-  color: rgb(120 53 15);
+  color: var(--warning-fg-strong);
   padding: 0.125rem;
   border-radius: 50%;
   display: flex;
@@ -33,7 +33,7 @@
   transition: background 0.15s;
 
   &:hover {
-    background: rgba(0, 0, 0, 0.08);
+    background: color-mix(in srgb, currentColor 12%, transparent);
   }
 
   mat-icon {
@@ -54,18 +54,4 @@
   }
 }
 
-html.dark {
-  .tier-alert-banner {
-    background: rgb(78 35 9);
-    border-color: rgb(217 119 6);
-    color: rgb(253 186 116);
-
-    mat-icon {
-      color: rgb(251 191 36);
-    }
-  }
-
-  .tier-alert-dismiss {
-    color: rgb(253 186 116);
-  }
-}
+// Dark mode handled entirely via theme variables (--warning-*).

--- a/apps/draft-assistant/frontend/src/app/features/draft/draft.component.scss
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft.component.scss
@@ -25,7 +25,7 @@
 }
 
 .info-card-copy {
-  color: rgb(71 85 105);
+  color: var(--text-muted);
   font-size: 0.875rem;
 }
 
@@ -69,7 +69,7 @@
 
 .section-hint {
   font-size: 0.75rem;
-  color: rgb(100 116 139);
+  color: var(--text-faint);
   flex: 1 0 auto;
   text-align: right;
 }
@@ -93,19 +93,9 @@
   }
 }
 
-html.dark {
-  .info-card-copy {
-    color: rgb(148 163 184);
-  }
-
-  .section-header h2 {
-    color: rgb(226 232 240);
-  }
-}
-
 .drawer-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgb(0 0 0 / 0.4);
   z-index: 199;
 }

--- a/apps/draft-assistant/frontend/src/app/features/draft/pick-explanation/pick-explanation.component.scss
+++ b/apps/draft-assistant/frontend/src/app/features/draft/pick-explanation/pick-explanation.component.scss
@@ -10,8 +10,8 @@
   border-radius: 1.5px;
   background: linear-gradient(
     90deg,
-    var(--mat-sys-tertiary, #7c3aed),
-    var(--mat-sys-primary, #2563eb)
+    var(--mat-sys-tertiary, var(--primary-container)),
+    var(--mat-sys-primary, var(--primary))
   );
   opacity: 0.7;
 }
@@ -31,9 +31,14 @@
   line-height: 1.3;
   padding: 0.15rem 0.45rem;
   border-radius: 0.75rem;
-  background: color-mix(in srgb, var(--mat-sys-surface-variant, #e2e8f0) 60%, transparent);
-  color: var(--mat-sys-on-surface-variant, #475569);
-  border: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant, #cbd5e1) 50%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--mat-sys-surface-variant, var(--border-subtle)) 60%,
+    transparent
+  );
+  color: var(--mat-sys-on-surface-variant, var(--text-muted));
+  border: 1px solid
+    color-mix(in srgb, var(--mat-sys-outline-variant, var(--border-default)) 50%, transparent);
   white-space: nowrap;
   font-style: italic;
 }

--- a/apps/draft-assistant/frontend/src/app/features/draft/player-detail-drawer/player-detail-drawer.component.scss
+++ b/apps/draft-assistant/frontend/src/app/features/draft/player-detail-drawer/player-detail-drawer.component.scss
@@ -18,9 +18,9 @@
 .drawer-panel {
   height: 100%;
   overflow-y: auto;
-  background: var(--mat-sys-surface, #fff);
-  border-left: 1px solid var(--mat-sys-outline-variant, #e0e0e0);
-  box-shadow: -4px 0 16px rgba(0, 0, 0, 0.12);
+  background: var(--mat-sys-surface, var(--surface));
+  border-left: 1px solid var(--mat-sys-outline-variant, var(--outline-variant));
+  box-shadow: -4px 0 16px rgb(0 0 0 / 0.12);
   display: flex;
   flex-direction: column;
   gap: 0;
@@ -33,7 +33,7 @@
   align-items: flex-start;
   gap: 0.75rem;
   padding: 1rem;
-  border-bottom: 1px solid var(--mat-sys-outline-variant, #e0e0e0);
+  border-bottom: 1px solid var(--mat-sys-outline-variant, var(--outline-variant));
   position: sticky;
   top: 0;
   background: inherit;
@@ -46,7 +46,7 @@
   border-radius: 50%;
   object-fit: cover;
   flex-shrink: 0;
-  background: var(--mat-sys-surface-variant, #f5f5f5);
+  background: var(--mat-sys-surface-variant, var(--surface-container-high));
 }
 
 .drawer-player-meta {
@@ -62,6 +62,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  color: var(--on-surface);
 }
 
 .drawer-sub {
@@ -71,7 +72,7 @@
   gap: 0.3rem;
   margin-top: 0.2rem;
   font-size: 0.75rem;
-  color: var(--mat-sys-on-surface-variant, #666);
+  color: var(--mat-sys-on-surface-variant, var(--text-faint));
 }
 
 .pos-badge {
@@ -81,20 +82,25 @@
   font-size: 0.7rem;
   font-weight: 700;
   text-transform: uppercase;
-  color: #fff;
+  background: var(--border-subtle);
+  color: var(--text-secondary);
 }
 
 .pos-badge--qb {
-  background: #ef4444;
+  background: var(--pos-qb-bg);
+  color: var(--pos-qb-fg);
 }
 .pos-badge--rb {
-  background: #22c55e;
+  background: var(--pos-rb-bg);
+  color: var(--pos-rb-fg);
 }
 .pos-badge--wr {
-  background: #3b82f6;
+  background: var(--pos-wr-bg);
+  color: var(--pos-wr-fg);
 }
 .pos-badge--te {
-  background: #f59e0b;
+  background: var(--pos-te-bg);
+  color: var(--pos-te-fg);
 }
 
 .injury-pill {
@@ -104,20 +110,20 @@
   font-weight: 600;
 }
 .injury-out {
-  background: #fca5a5;
-  color: #991b1b;
+  background: var(--danger-bg);
+  color: var(--danger-fg);
 }
 .injury-doubtful {
-  background: #fbbf24;
-  color: #78350f;
+  background: var(--warning-bg);
+  color: var(--warning-fg);
 }
 .injury-q {
-  background: #fde68a;
-  color: #92400e;
+  background: var(--caution-bg);
+  color: var(--caution-fg);
 }
 .injury-other {
-  background: #e5e7eb;
-  color: #374151;
+  background: var(--surface-muted);
+  color: var(--text-secondary);
 }
 
 .drawer-close-btn {
@@ -129,7 +135,7 @@
 
 .drawer-section {
   padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--mat-sys-outline-variant, #e0e0e0);
+  border-bottom: 1px solid var(--mat-sys-outline-variant, var(--outline-variant));
 }
 
 .drawer-section:last-child {
@@ -141,7 +147,7 @@
   font-weight: 700;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: var(--mat-sys-on-surface-variant, #666);
+  color: var(--mat-sys-on-surface-variant, var(--text-faint));
   margin: 0 0 0.5rem;
 }
 
@@ -159,7 +165,7 @@
 }
 
 .stat-label {
-  color: var(--mat-sys-on-surface-variant, #666);
+  color: var(--mat-sys-on-surface-variant, var(--text-faint));
   white-space: nowrap;
   width: 30%;
 }
@@ -168,37 +174,38 @@
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   width: 20%;
+  color: var(--on-surface);
 }
 
 .wcs-highlight {
-  color: var(--mat-sys-primary, #1d4ed8);
+  color: var(--mat-sys-primary, var(--primary-on-active));
 }
 
 .adp-std {
-  color: var(--mat-sys-on-surface-variant, #888);
+  color: var(--text-disabled);
   font-weight: 400;
   font-size: 0.75em;
   margin-left: 0.15rem;
 }
 
 .trend-up {
-  color: #16a34a;
+  color: var(--success);
 }
 .trend-down {
-  color: #dc2626;
+  color: var(--danger);
 }
 
 .eff-a {
-  color: #15803d;
+  color: var(--success-strong);
 }
 .eff-b {
-  color: #0369a1;
+  color: var(--info-strong);
 }
 .eff-c {
-  color: #b45309;
+  color: var(--warning);
 }
 .eff-d {
-  color: #b91c1c;
+  color: var(--danger-strong);
 }
 
 // ── Placeholder ───────────────────────────────────────────────────────────────
@@ -210,7 +217,7 @@
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  color: var(--mat-sys-on-surface-variant, #999);
+  color: var(--mat-sys-on-surface-variant, var(--text-disabled));
   padding: 2rem;
 
   mat-icon {
@@ -227,78 +234,8 @@
 
 .drawer-empty {
   font-size: 0.8rem;
-  color: var(--mat-sys-on-surface-variant, #888);
+  color: var(--mat-sys-on-surface-variant, var(--text-faint));
   margin: 0.25rem 0 0;
 }
 
-// ── Dark mode ─────────────────────────────────────────────────────────────────
-
-html.dark {
-  .drawer-panel {
-    background: rgb(15 13 19);
-    border-left-color: rgb(30 41 59);
-  }
-
-  .drawer-header,
-  .drawer-section {
-    border-bottom-color: rgb(30 41 59);
-  }
-
-  .drawer-section-title,
-  .stat-label,
-  .drawer-sub,
-  .drawer-empty {
-    color: rgb(100 116 139);
-  }
-
-  .drawer-name,
-  .stat-val {
-    color: rgb(226 232 240);
-  }
-
-  .wcs-highlight {
-    color: rgb(129 140 248);
-  }
-
-  .adp-std {
-    color: rgb(71 85 105);
-  }
-
-  .pos-badge--qb {
-    background: rgb(127 29 29);
-    color: rgb(252 165 165);
-  }
-  .pos-badge--rb {
-    background: rgb(20 83 45);
-    color: rgb(134 239 172);
-  }
-  .pos-badge--wr {
-    background: rgb(30 58 138);
-    color: rgb(147 197 253);
-  }
-  .pos-badge--te {
-    background: rgb(120 53 15);
-    color: rgb(253 186 116);
-  }
-
-  .injury-out {
-    background: rgb(127 29 29);
-    color: rgb(252 165 165);
-  }
-  .injury-doubtful {
-    background: rgb(120 53 15);
-    color: rgb(253 186 116);
-  }
-  .injury-q {
-    background: rgb(113 63 18);
-    color: rgb(253 224 71);
-  }
-  .injury-other {
-    background: rgb(30 41 59);
-    color: rgb(148 163 184);
-  }
-
-  .drawer-placeholder {
-    color: rgb(71 85 105);
-  }
-}
+// All colors come from theme variables — no html.dark block needed.

--- a/apps/draft-assistant/frontend/src/app/features/players/players.component.scss
+++ b/apps/draft-assistant/frontend/src/app/features/players/players.component.scss
@@ -63,11 +63,11 @@
 .expand-btn {
   flex-shrink: 0;
   align-self: center;
-  color: rgb(100 116 139);
+  color: var(--text-faint);
   margin-left: 0.125rem;
 
   &:hover {
-    background: rgb(241 245 249);
+    background: var(--surface-muted);
   }
 }
 
@@ -91,43 +91,23 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1rem;
-  background: rgb(254 249 195);
-  border: 1px solid rgb(252 211 77);
+  background: var(--caution-bg);
+  border: 1px solid var(--caution-border-soft);
   border-radius: 0.5rem;
   font-size: 0.875rem;
-  color: rgb(120 53 15);
+  color: var(--warning-fg-strong);
 
   mat-icon {
-    color: rgb(161 98 7);
+    color: var(--warning);
     flex-shrink: 0;
   }
 
   code {
     font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
     font-size: 0.8125rem;
-    background: rgb(254 243 199);
+    background: var(--warning-bg-soft);
     padding: 0.1rem 0.3rem;
     border-radius: 0.25rem;
-  }
-}
-
-html.dark {
-  .expand-btn:hover {
-    background: rgb(30 41 59);
-  }
-
-  .stale-banner {
-    background: rgb(78 35 9);
-    border-color: rgb(217 119 6);
-    color: rgb(253 186 116);
-
-    mat-icon {
-      color: rgb(251 191 36);
-    }
-
-    code {
-      background: rgb(66 32 6);
-      color: rgb(253 211 77);
-    }
+    color: var(--caution-fg);
   }
 }

--- a/apps/draft-assistant/frontend/src/app/features/team-view/team-view-players-list/team-view-players-list.component.scss
+++ b/apps/draft-assistant/frontend/src/app/features/team-view/team-view-players-list/team-view-players-list.component.scss
@@ -74,7 +74,7 @@
 }
 
 .status-pill--warn {
-  background: color-mix(in srgb, #ef4444 16%, var(--surface-container-high));
+  background: color-mix(in srgb, var(--danger-border) 16%, var(--surface-container-high));
 }
 
 .expand-button {

--- a/apps/draft-assistant/frontend/src/app/shared/components/app-nav/app-nav.component.scss
+++ b/apps/draft-assistant/frontend/src/app/shared/components/app-nav/app-nav.component.scss
@@ -113,7 +113,7 @@
 }
 
 .nav-league-check {
-  color: rgb(22 163 74);
+  color: var(--success);
   font-size: 1rem;
   width: 1rem;
   height: 1rem;
@@ -169,21 +169,19 @@
 }
 
 // ── Dark mode ─────────────────────────────────────────
+// Active-item styling intensifies in dark; --primary-on-active swaps to a
+// lighter primary tint for legibility against the dark surface.
 html.dark {
   .nav-item--active {
     background: color-mix(in srgb, var(--primary) 22%, transparent);
-    color: #c4b5fd;
+    color: var(--primary-on-active);
 
     .nav-item-icon {
-      color: #c4b5fd;
+      color: var(--primary-on-active);
     }
   }
 
   .nav-item:hover {
     background: color-mix(in srgb, var(--primary) 12%, transparent);
-  }
-
-  .nav-league-check {
-    color: rgb(74 222 128);
   }
 }

--- a/apps/draft-assistant/frontend/src/app/shared/components/bottom-nav/bottom-nav.component.scss
+++ b/apps/draft-assistant/frontend/src/app/shared/components/bottom-nav/bottom-nav.component.scss
@@ -31,7 +31,7 @@
 }
 
 .bottom-nav-league-icon {
-  color: rgb(22 163 74);
+  color: var(--success);
   font-size: 1rem;
   width: 1rem;
   height: 1rem;
@@ -130,18 +130,11 @@
 }
 
 // ── Dark mode ─────────────────────────────────────────
+// Active-item primary swaps to a lighter tint (--primary-on-active) and the
+// pill behind it deepens for contrast against the dark surface.
 html.dark {
-  .bottom-nav {
-    background: var(--surface-container-low);
-    border-top-color: var(--outline-variant);
-  }
-
-  .bottom-nav-league-icon {
-    color: rgb(74 222 128);
-  }
-
   .bottom-nav-item--active {
-    color: #c4b5fd;
+    color: var(--primary-on-active);
 
     .bottom-nav-pill {
       background: color-mix(in srgb, var(--primary) 22%, transparent);

--- a/apps/draft-assistant/frontend/src/app/shared/components/dark-mode-toggle/dark-mode-toggle.component.scss
+++ b/apps/draft-assistant/frontend/src/app/shared/components/dark-mode-toggle/dark-mode-toggle.component.scss
@@ -32,7 +32,7 @@
   flex-shrink: 0;
 
   &:hover {
-    background: rgba(255, 255, 255, 0.15);
+    background: color-mix(in srgb, currentColor 15%, transparent);
   }
 
   &:focus-visible {

--- a/apps/draft-assistant/frontend/src/app/shared/components/error-state/error-state.component.scss
+++ b/apps/draft-assistant/frontend/src/app/shared/components/error-state/error-state.component.scss
@@ -7,5 +7,5 @@
 
 .error-message {
   margin: 0;
-  color: var(--mat-sys-error, #b3261e);
+  color: var(--mat-sys-error, var(--danger));
 }

--- a/apps/draft-assistant/frontend/src/app/shared/components/page-header/page-header.component.scss
+++ b/apps/draft-assistant/frontend/src/app/shared/components/page-header/page-header.component.scss
@@ -15,7 +15,7 @@
 }
 
 .page-header-subtitle {
-  color: var(--mat-sys-on-surface-variant, #49454f);
+  color: var(--mat-sys-on-surface-variant, var(--text-muted));
   font-size: 0.9375rem;
   margin: 0;
 }

--- a/apps/draft-assistant/frontend/src/app/shared/components/player-card/player-card.component.scss
+++ b/apps/draft-assistant/frontend/src/app/shared/components/player-card/player-card.component.scss
@@ -9,10 +9,10 @@
   // Use CSS custom properties set by the global tier classes so they cascade
   // through Angular's emulated encapsulation boundary.  Defaults to the
   // untiered appearance when no tier class is present.
-  border: 2px solid var(--tier-card-border, rgb(203 213 225));
+  border: 2px solid var(--tier-card-border, var(--border-default));
   border-radius: 0.5rem;
   overflow: hidden;
-  background: var(--tier-card-bg, var(--surface-container-lowest, #ffffff));
+  background: var(--tier-card-bg, var(--surface-container-lowest));
   transition: box-shadow 0.15s ease;
 
   &:hover {
@@ -41,7 +41,7 @@
   width: 4px;
   align-self: stretch;
   flex-shrink: 0;
-  background: rgb(203 213 225); // default / unknown
+  background: var(--border-default); // default / unknown
 }
 
 // ── Card inner (flex column, fills remaining width after accent bar) ──────────
@@ -54,19 +54,19 @@
 }
 
 .pos-accent-qb {
-  background: rgb(239 68 68);
+  background: var(--pos-qb);
 }
 
 .pos-accent-rb {
-  background: rgb(34 197 94);
+  background: var(--pos-rb);
 }
 
 .pos-accent-wr {
-  background: rgb(59 130 246);
+  background: var(--pos-wr);
 }
 
 .pos-accent-te {
-  background: rgb(249 115 22);
+  background: var(--pos-te);
 }
 
 // ── Header row ────────────────────────────────────────────────────────────────
@@ -83,7 +83,7 @@
   height: 2.25rem;
   border-radius: 9999px;
   object-fit: cover;
-  background: rgb(226 232 240);
+  background: var(--border-subtle);
   flex-shrink: 0;
 }
 
@@ -103,7 +103,7 @@
 
   &--drafted {
     text-decoration: line-through;
-    color: rgb(148 163 184);
+    color: var(--text-disabled);
   }
 }
 
@@ -112,12 +112,12 @@
   align-items: center;
   gap: 0.25rem;
   font-size: 0.75rem;
-  color: rgb(100 116 139);
+  color: var(--text-faint);
   flex-wrap: wrap;
 }
 
 .sub-sep {
-  color: rgb(203 213 225);
+  color: var(--border-default);
 }
 
 // ── Position badge ────────────────────────────────────────────────────────────
@@ -129,27 +129,27 @@
   letter-spacing: 0.05em;
   border-radius: 0.25rem;
   padding: 0.0625rem 0.3125rem;
-  background: rgb(226 232 240);
-  color: rgb(51 65 85);
+  background: var(--border-subtle);
+  color: var(--text-secondary);
 
   &--qb {
-    background: rgb(254 226 226);
-    color: rgb(185 28 28);
+    background: var(--pos-qb-bg);
+    color: var(--pos-qb-fg);
   }
 
   &--rb {
-    background: rgb(220 252 231);
-    color: rgb(22 101 52);
+    background: var(--pos-rb-bg);
+    color: var(--pos-rb-fg);
   }
 
   &--wr {
-    background: rgb(219 234 254);
-    color: rgb(29 78 216);
+    background: var(--pos-wr-bg);
+    color: var(--pos-wr-fg);
   }
 
   &--te {
-    background: rgb(255 237 213);
-    color: rgb(154 52 18);
+    background: var(--pos-te-bg);
+    color: var(--pos-te-fg);
   }
 }
 
@@ -167,14 +167,14 @@
   gap: 0.375rem;
   flex-wrap: wrap;
   padding: 0.1875rem 0.5rem 0.375rem;
-  border-top: 1px solid rgb(226 232 240);
+  border-top: 1px solid var(--border-subtle);
 }
 
 .meta-pill {
   display: inline-flex;
   flex-direction: column;
   align-items: center;
-  background: rgb(241 245 249);
+  background: var(--surface-muted);
   border-radius: 0.3rem;
   padding: 0.0625rem 0.375rem;
   min-width: 2rem;
@@ -184,7 +184,7 @@
 .pill-label {
   font-size: 0.55rem;
   font-weight: 600;
-  color: rgb(100 116 139);
+  color: var(--text-faint);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   line-height: 1.2;
@@ -193,49 +193,40 @@
 .pill-val {
   font-size: 0.7rem;
   font-weight: 700;
-  color: rgb(30 41 59);
+  color: var(--text-heading);
   line-height: 1.2;
   white-space: nowrap;
 }
 
 .eff-pill {
   &.eff-high {
-    background: rgb(187 247 208);
+    background: var(--success-bold-bg);
 
-    .pill-label {
-      color: rgb(22 101 52);
-    }
-
+    .pill-label,
     .pill-val {
-      color: rgb(22 101 52);
+      color: var(--success-strong);
     }
   }
 
   &.eff-mid {
-    background: rgb(254 249 195);
+    background: var(--caution-bg);
 
-    .pill-label {
-      color: rgb(113 63 18);
-    }
-
+    .pill-label,
     .pill-val {
-      color: rgb(92 45 12);
+      color: var(--caution-fg);
     }
   }
 
   &.eff-neutral {
-    background: rgb(241 245 249);
+    background: var(--surface-muted);
   }
 
   &.eff-low {
-    background: rgb(254 226 226);
+    background: var(--danger-bg);
 
-    .pill-label {
-      color: rgb(153 27 27);
-    }
-
+    .pill-label,
     .pill-val {
-      color: rgb(153 27 27);
+      color: var(--danger-fg);
     }
   }
 }
@@ -249,15 +240,15 @@
 }
 
 .adp-value {
-  color: rgb(22 163 74);
+  color: var(--success);
 }
 
 .adp-reach {
-  color: rgb(220 38 38);
+  color: var(--danger);
 }
 
 .adp-neutral {
-  color: rgb(100 116 139);
+  color: var(--text-faint);
 }
 
 // ── Card actions ──────────────────────────────────────────────────────────────
@@ -273,25 +264,25 @@
   font-weight: 600;
   padding: 0.125rem 0.375rem;
   border-radius: 999px;
-  background: rgb(220 252 231);
-  color: rgb(22 101 52);
+  background: var(--success-soft-bg);
+  color: var(--success-strong);
   white-space: nowrap;
 
   &.at-risk {
-    background: rgb(254 226 226);
-    color: rgb(153 27 27);
+    background: var(--danger-bg);
+    color: var(--danger-fg);
   }
 }
 
 .star-btn {
-  color: rgb(100 116 139);
+  color: var(--text-faint);
 
   &:hover {
-    background: rgb(241 245 249);
+    background: var(--surface-muted);
   }
 
   &--active {
-    color: rgb(202 138 4);
+    color: var(--star-active);
   }
 }
 
@@ -300,9 +291,9 @@
   align-items: center;
   font-size: 0.6rem;
   font-weight: 700;
-  color: rgb(154 52 18);
-  background: rgb(255 237 213);
-  border: 1px solid rgb(251 146 60);
+  color: var(--warning-fg);
+  background: var(--warning-bg);
+  border: 1px solid var(--warning-border);
   border-radius: 999px;
   padding: 0 0.3125rem;
   margin-left: 0.3125rem;
@@ -336,21 +327,21 @@
 }
 
 .injury-out {
-  background: rgb(254 226 226);
-  border: 1px solid rgb(239 68 68);
-  color: rgb(153 27 27);
+  background: var(--danger-bg);
+  border: 1px solid var(--danger-border);
+  color: var(--danger-fg);
 }
 
 .injury-doubtful {
-  background: rgb(255 237 213);
-  border: 1px solid rgb(249 115 22);
-  color: rgb(154 52 18);
+  background: var(--warning-bg);
+  border: 1px solid var(--warning-border);
+  color: var(--warning-fg);
 }
 
 .injury-questionable {
-  background: rgb(254 249 195);
-  border: 1px solid rgb(234 179 8);
-  color: rgb(113 63 18);
+  background: var(--caution-bg);
+  border: 1px solid var(--caution-border);
+  color: var(--caution-fg);
 }
 
 // ── Trending badge ────────────────────────────────────────────────────────────
@@ -359,7 +350,7 @@
   align-items: center;
   font-size: 0.6rem;
   font-weight: 700;
-  color: rgb(22 163 74);
+  color: var(--success);
   margin-left: 0.25rem;
   vertical-align: middle;
 }
@@ -371,9 +362,9 @@
   font-size: 0.55rem;
   font-weight: 800;
   letter-spacing: 0.04em;
-  color: rgb(120 53 15);
-  background: rgb(254 243 199);
-  border: 1px solid rgb(251 191 36);
+  color: var(--warning-fg-strong);
+  background: var(--warning-bg-soft);
+  border: 1px solid var(--warning-border-strong);
   border-radius: 999px;
   padding: 0 0.25rem;
   margin-left: 0.25rem;
@@ -384,7 +375,7 @@
 .pos-rank {
   font-size: 0.65rem;
   font-weight: 600;
-  color: rgb(100 116 139);
+  color: var(--text-faint);
   letter-spacing: 0.01em;
 }
 
@@ -395,22 +386,22 @@
   padding: 0.125rem 0.375rem;
   border-radius: 0.3rem;
   white-space: nowrap;
-  background: rgb(226 232 240);
-  color: rgb(51 65 85);
+  background: var(--border-subtle);
+  color: var(--text-secondary);
 
   &.wcs-high {
-    background: rgb(187 247 208);
-    color: rgb(22 101 52);
+    background: var(--success-bold-bg);
+    color: var(--success-strong);
   }
 
   &.wcs-mid {
-    background: rgb(254 249 195);
-    color: rgb(113 63 18);
+    background: var(--caution-bg);
+    color: var(--caution-fg);
   }
 
   &.wcs-low {
-    background: rgb(241 245 249);
-    color: rgb(100 116 139);
+    background: var(--surface-muted);
+    color: var(--text-faint);
   }
 }
 
@@ -420,11 +411,11 @@
   padding: 0.25rem 0.5rem 0.3125rem;
   font-size: 0.6875rem;
   font-style: italic;
-  color: rgb(100 116 139);
+  color: var(--text-faint);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  border-top: 1px solid rgb(226 232 240);
+  border-top: 1px solid var(--border-subtle);
 }
 
 // ── Stats row ─────────────────────────────────────────────────────────────────
@@ -433,8 +424,8 @@
   align-items: center;
   gap: 0;
   padding: 0.375rem 0.5rem 0.375rem 3.25rem; // align with player-meta (avatar width + padding)
-  background: var(--surface-container-low, rgb(247 242 245));
-  border-top: 1px solid rgb(226 232 240);
+  background: var(--surface-container-low);
+  border-top: 1px solid var(--border-subtle);
 
   &--drafted {
     opacity: 0.6;
@@ -447,7 +438,7 @@
   align-items: center;
   min-width: 4rem;
   padding: 0 0.375rem;
-  border-right: 1px solid rgb(226 232 240);
+  border-right: 1px solid var(--border-subtle);
   flex: 1;
 
   &:last-child {
@@ -458,225 +449,17 @@
 .stat-value {
   font-size: 0.8125rem;
   font-weight: 700;
-  color: rgb(30 41 59);
+  color: var(--text-heading);
   white-space: nowrap;
 }
 
 .stat-label {
   font-size: 0.625rem;
   font-weight: 500;
-  color: rgb(100 116 139);
+  color: var(--text-faint);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   white-space: nowrap;
-}
-
-// ── Dark-mode overrides ────────────────────────────────────────────────────────
-html.dark {
-  .player-card {
-    border-color: var(--tier-card-border, rgb(51 65 85));
-    background: var(--tier-card-bg, var(--surface-container-lowest, rgb(15 13 19)));
-  }
-
-  .pos-accent {
-    background: rgb(51 65 85);
-  }
-
-  .player-avatar {
-    background: rgb(51 65 85);
-  }
-
-  .player-sub {
-    color: rgb(100 116 139);
-  }
-
-  .sub-sep {
-    color: rgb(51 65 85);
-  }
-
-  .pos-badge {
-    background: rgb(51 65 85);
-    color: rgb(148 163 184);
-
-    &--qb {
-      background: rgb(127 29 29);
-      color: rgb(252 165 165);
-    }
-
-    &--rb {
-      background: rgb(20 83 45);
-      color: rgb(134 239 172);
-    }
-
-    &--wr {
-      background: rgb(30 58 138);
-      color: rgb(147 197 253);
-    }
-
-    &--te {
-      background: rgb(67 20 7);
-      color: rgb(253 186 116);
-    }
-  }
-
-  .pills-row {
-    border-top-color: rgb(51 65 85);
-  }
-
-  .meta-pill {
-    background: rgb(30 41 59);
-  }
-
-  .pill-label {
-    color: rgb(71 85 105);
-  }
-
-  .pill-val {
-    color: rgb(148 163 184);
-  }
-
-  .eff-pill {
-    &.eff-high {
-      background: rgb(6 78 59);
-
-      .pill-label,
-      .pill-val {
-        color: rgb(110 231 183);
-      }
-    }
-
-    &.eff-mid {
-      background: rgb(66 32 6);
-
-      .pill-label,
-      .pill-val {
-        color: rgb(252 211 77);
-      }
-    }
-
-    &.eff-neutral {
-      background: rgb(30 41 59);
-    }
-
-    &.eff-low {
-      background: rgb(127 29 29);
-
-      .pill-label,
-      .pill-val {
-        color: rgb(252 165 165);
-      }
-    }
-  }
-
-  .player-name--drafted {
-    color: rgb(71 85 105);
-  }
-
-  .star-btn:hover {
-    background: rgb(30 41 59);
-  }
-
-  .availability-badge {
-    background: rgb(20 83 45);
-    color: rgb(134 239 172);
-
-    &.at-risk {
-      background: rgb(127 29 29);
-      color: rgb(252 165 165);
-    }
-  }
-
-  .going-soon-badge {
-    background: rgb(67 20 7);
-    border-color: rgb(234 88 12);
-    color: rgb(253 186 116);
-  }
-
-  .injury-out {
-    background: rgb(127 29 29);
-    border-color: rgb(220 38 38);
-    color: rgb(252 165 165);
-  }
-
-  .injury-doubtful {
-    background: rgb(67 20 7);
-    border-color: rgb(234 88 12);
-    color: rgb(253 186 116);
-  }
-
-  .injury-questionable {
-    background: rgb(66 32 6);
-    border-color: rgb(202 138 4);
-    color: rgb(252 211 77);
-  }
-
-  .trending-badge {
-    color: rgb(74 222 128);
-  }
-
-  .rookie-badge {
-    background: rgb(78 52 0);
-    border-color: rgb(180 130 6);
-    color: rgb(253 230 138);
-  }
-
-  .pos-rank {
-    color: rgb(71 85 105);
-  }
-
-  .wcs-badge {
-    background: rgb(30 41 59);
-    color: rgb(148 163 184);
-
-    &.wcs-high {
-      background: rgb(6 78 59);
-      color: rgb(110 231 183);
-    }
-
-    &.wcs-mid {
-      background: rgb(66 32 6);
-      color: rgb(252 211 77);
-    }
-
-    &.wcs-low {
-      background: rgb(15 23 42);
-      color: rgb(71 85 105);
-    }
-  }
-
-  .adp-value {
-    color: rgb(74 222 128);
-  }
-
-  .adp-reach {
-    color: rgb(252 165 165);
-  }
-
-  .adp-neutral {
-    color: rgb(100 116 139);
-  }
-
-  .player-explanation {
-    color: rgb(71 85 105);
-    border-top-color: rgb(51 65 85);
-  }
-
-  .stats-row {
-    background: var(--surface-container-low, rgb(29 27 32));
-    border-top-color: rgb(51 65 85);
-  }
-
-  .stat-chip {
-    border-right-color: rgb(51 65 85);
-  }
-
-  .stat-value {
-    color: rgb(226 232 240);
-  }
-
-  .stat-label {
-    color: rgb(100 116 139);
-  }
 }
 
 // ── Responsive ────────────────────────────────────────────────────────────────

--- a/apps/draft-assistant/frontend/src/app/shared/components/player-row/player-row.component.scss
+++ b/apps/draft-assistant/frontend/src/app/shared/components/player-row/player-row.component.scss
@@ -7,7 +7,7 @@
   grid-template-columns: auto minmax(0, 1fr) auto auto auto;
   align-items: center;
   gap: 0.5rem;
-  border: 1px solid rgb(226 232 240);
+  border: 1px solid var(--border-subtle);
   border-radius: 0.5rem;
   padding: 0.5rem;
 }
@@ -17,7 +17,7 @@
   height: 2rem;
   border-radius: 9999px;
   object-fit: cover;
-  background: rgb(226 232 240);
+  background: var(--border-subtle);
   flex-shrink: 0;
 }
 
@@ -36,55 +36,31 @@
 
 .player-sub {
   font-size: 0.75rem;
-  color: rgb(100 116 139);
+  color: var(--text-faint);
 }
 
 .player-rank {
   font-size: 0.8125rem;
-  color: rgb(51 65 85);
+  color: var(--text-secondary);
   white-space: nowrap;
 }
 
 .player-value {
   font-size: 0.8125rem;
-  color: rgb(51 65 85);
+  color: var(--text-secondary);
   white-space: nowrap;
 }
 
 .star-button {
-  color: rgb(100 116 139);
+  color: var(--text-faint);
 
   &:hover {
-    background: rgb(241 245 249);
+    background: var(--surface-muted);
   }
 }
 
 .star-active {
-  color: rgb(202 138 4);
-}
-
-// ── Dark-mode overrides ────────────────────────────────────────────────────────
-html.dark {
-  .player-row {
-    border-color: rgb(51 65 85);
-  }
-
-  .player-sub {
-    color: rgb(100 116 139);
-  }
-
-  .player-rank,
-  .player-value {
-    color: rgb(148 163 184);
-  }
-
-  .star-button:hover {
-    background: rgb(30 41 59);
-  }
-
-  .player-avatar {
-    background: rgb(51 65 85);
-  }
+  color: var(--star-active);
 }
 
 // ── Responsive ─────────────────────────────────────────────────────────────────

--- a/apps/draft-assistant/frontend/src/app/shared/components/tier-legend/tier-legend.component.scss
+++ b/apps/draft-assistant/frontend/src/app/shared/components/tier-legend/tier-legend.component.scss
@@ -14,7 +14,7 @@
   border-radius: 0.25rem;
   font-size: 0.625rem;
   font-weight: 700;
-  color: var(--on-surface, rgb(51 65 85));
+  color: var(--on-surface);
 }
 
 // Tier color classes (.tier-1 through .tier-unranked) are defined globally in styles.scss

--- a/apps/draft-assistant/frontend/src/app/shared/styles/_position-colors.scss
+++ b/apps/draft-assistant/frontend/src/app/shared/styles/_position-colors.scss
@@ -1,79 +1,52 @@
 // ── Position color tokens ──────────────────────────────────────────────────────
 // Extracted from draft-board-grid.component.scss.
 // Global utility classes for position-based background + border coloring.
+// Position color values come from --pos-{qb,rb,wr,te} in styles.scss; dark-mode
+// label uses --pos-{qb,rb,wr,te}-fg.
 // ──────────────────────────────────────────────────────────────────────────────
 
-.pos-qb {
-  background: rgba(239, 68, 68, 0.16) !important;
-  border-color: rgba(239, 68, 68, 0.28) !important;
+@mixin pos-tint($solid, $label, $bg-pct, $border-pct, $label-pct) {
+  background: color-mix(in srgb, #{$solid} $bg-pct, transparent) !important;
+  border-color: color-mix(in srgb, #{$solid} $border-pct, transparent) !important;
 
   .cell-label {
-    color: rgba(185, 28, 28, 0.55);
+    color: color-mix(in srgb, #{$label} $label-pct, transparent);
   }
+}
+
+.pos-qb {
+  @include pos-tint(var(--pos-qb), var(--pos-qb-fg), 16%, 28%, 55%);
 }
 
 .pos-rb {
-  background: rgba(34, 197, 94, 0.16) !important;
-  border-color: rgba(34, 197, 94, 0.28) !important;
-
-  .cell-label {
-    color: rgba(21, 128, 61, 0.55);
-  }
+  @include pos-tint(var(--pos-rb), var(--pos-rb-fg), 16%, 28%, 55%);
 }
 
 .pos-wr {
-  background: rgba(59, 130, 246, 0.16) !important;
-  border-color: rgba(59, 130, 246, 0.28) !important;
-
-  .cell-label {
-    color: rgba(29, 78, 216, 0.55);
-  }
+  @include pos-tint(var(--pos-wr), var(--pos-wr-fg), 16%, 28%, 55%);
 }
 
 .pos-te {
-  background: rgba(249, 115, 22, 0.16) !important;
-  border-color: rgba(249, 115, 22, 0.28) !important;
-
-  .cell-label {
-    color: rgba(194, 65, 12, 0.55);
-  }
+  @include pos-tint(var(--pos-te), var(--pos-te-fg), 16%, 28%, 55%);
 }
 
 // ── Dark-mode overrides ────────────────────────────────────────────────────────
+// Higher alphas keep the tint visible against the dark surface; --pos-*-fg
+// already swaps to a lighter shade for label legibility.
 html.dark {
   .pos-qb {
-    background: rgba(239, 68, 68, 0.22) !important;
-    border-color: rgba(239, 68, 68, 0.45) !important;
-
-    .cell-label {
-      color: rgba(252, 165, 165, 0.7);
-    }
+    @include pos-tint(var(--pos-qb), var(--pos-qb-fg), 22%, 45%, 70%);
   }
 
   .pos-rb {
-    background: rgba(34, 197, 94, 0.22) !important;
-    border-color: rgba(34, 197, 94, 0.45) !important;
-
-    .cell-label {
-      color: rgba(134, 239, 172, 0.7);
-    }
+    @include pos-tint(var(--pos-rb), var(--pos-rb-fg), 22%, 45%, 70%);
   }
 
   .pos-wr {
-    background: rgba(59, 130, 246, 0.22) !important;
-    border-color: rgba(59, 130, 246, 0.45) !important;
-
-    .cell-label {
-      color: rgba(147, 197, 253, 0.7);
-    }
+    @include pos-tint(var(--pos-wr), var(--pos-wr-fg), 22%, 45%, 70%);
   }
 
   .pos-te {
-    background: rgba(249, 115, 22, 0.22) !important;
-    border-color: rgba(249, 115, 22, 0.45) !important;
-
-    .cell-label {
-      color: rgba(253, 186, 116, 0.7);
-    }
+    @include pos-tint(var(--pos-te), var(--pos-te-fg), 22%, 45%, 70%);
   }
 }

--- a/apps/draft-assistant/frontend/src/app/shared/styles/_states.scss
+++ b/apps/draft-assistant/frontend/src/app/shared/styles/_states.scss
@@ -22,32 +22,19 @@
 // ── Empty / no-data ───────────────────────────────────────────────────────────
 .empty-copy {
   font-size: 0.875rem;
-  color: rgb(71 85 105);
+  color: var(--text-muted);
   padding: 0.25rem 0;
 }
 
 // ── Warning banner ────────────────────────────────────────────────────────────
 .warning-banner {
   border-radius: 0.5rem;
-  border: 1px solid rgb(252 211 77);
-  background: rgb(255 251 235);
-  color: rgb(120 53 15);
+  border: 1px solid var(--caution-border-soft);
+  background: color-mix(in srgb, var(--caution-bg) 50%, var(--surface));
+  color: var(--warning-fg-strong);
   padding: 0.5rem 0.75rem;
   display: flex;
   align-items: center;
   gap: 0.5rem;
   font-size: 0.875rem;
-}
-
-// ── Dark-mode overrides ────────────────────────────────────────────────────────
-html.dark {
-  .empty-copy {
-    color: rgb(148 163 184);
-  }
-
-  .warning-banner {
-    border-color: rgb(180 130 20);
-    background: rgb(40 30 5);
-    color: rgb(253 211 77);
-  }
 }

--- a/apps/draft-assistant/frontend/src/app/shared/styles/_tier-colors.scss
+++ b/apps/draft-assistant/frontend/src/app/shared/styles/_tier-colors.scss
@@ -35,10 +35,10 @@ $_tiers: (
 }
 
 .tier-unranked {
-  background: rgb(241 245 249);
-  border: 2px solid rgb(203 213 225);
-  --tier-card-border: rgb(203 213 225);
-  --tier-card-bg: rgb(241 245 249);
+  background: var(--surface-muted);
+  border: 2px solid var(--border-default);
+  --tier-card-border: var(--border-default);
+  --tier-card-bg: var(--surface-muted);
 }
 
 // ── Players-table row variants (prefixed with row-) ────────────────────────────
@@ -52,11 +52,14 @@ $_tiers: (
 }
 
 .row-tier-unranked {
-  background: rgb(241 245 249);
-  border: 2px solid rgb(203 213 225);
+  background: var(--surface-muted);
+  border: 2px solid var(--border-default);
 }
 
 // ── Dark-mode overrides ────────────────────────────────────────────────────────
+// Tier numeric backgrounds/borders use bespoke per-tier dark values; the
+// "unranked" neutral picks up its colors from the theme variables above and
+// needs no override.
 html.dark {
   @each $tier, $bg, $border, $bg-dark, $border-dark in $_tiers {
     .tier-#{$tier} {
@@ -67,22 +70,10 @@ html.dark {
     }
   }
 
-  .tier-unranked {
-    background: rgb(30 30 35);
-    border-color: rgb(75 85 99);
-    --tier-card-border: rgb(75 85 99);
-    --tier-card-bg: rgb(30 30 35);
-  }
-
   @each $tier, $bg, $border, $bg-dark, $border-dark in $_tiers {
     .row-tier-#{$tier} {
       border-color: $border-dark;
       background: $bg-dark;
     }
-  }
-
-  .row-tier-unranked {
-    background: rgb(30 30 35);
-    border-color: rgb(75 85 99);
   }
 }

--- a/apps/draft-assistant/frontend/src/app/shared/styles/_typography.scss
+++ b/apps/draft-assistant/frontend/src/app/shared/styles/_typography.scss
@@ -10,7 +10,7 @@
 
 .page-subtitle {
   font-size: 0.875rem;
-  color: rgb(71 85 105);
+  color: var(--text-muted);
 }
 
 .section-title {
@@ -36,18 +36,7 @@
 
 .section-hint {
   font-size: 0.75rem;
-  color: rgb(100 116 139);
+  color: var(--text-faint);
   flex: 1 0 auto;
   text-align: right;
-}
-
-// ── Dark-mode overrides ────────────────────────────────────────────────────────
-html.dark {
-  .page-subtitle {
-    color: rgb(148 163 184);
-  }
-
-  .section-hint {
-    color: rgb(100 116 139);
-  }
 }

--- a/apps/draft-assistant/frontend/src/styles.scss
+++ b/apps/draft-assistant/frontend/src/styles.scss
@@ -213,22 +213,22 @@ html.dark {
   --success-bold-bg: rgb(6 78 59);
   --success-border: rgb(34 197 94);
 
-  --danger: rgb(252 165 165);
-  --danger-strong: rgb(252 165 165);
-  --danger-fg: rgb(252 165 165);
+  --danger: rgb(248 113 113); // red-400 — solid/icon use on neutral surface
+  --danger-strong: rgb(254 202 202); // red-200 — emphasized danger text
+  --danger-fg: rgb(252 165 165); // red-300 — text on --danger-bg
   --danger-bg: rgb(127 29 29);
   --danger-border: rgb(220 38 38);
 
   --warning: rgb(251 191 36);
-  --warning-fg: rgb(253 186 116);
-  --warning-fg-strong: rgb(253 186 116);
+  --warning-fg: rgb(253 186 116); // orange-300 — text on --warning-bg
+  --warning-fg-strong: rgb(254 215 170); // orange-200 — emphasized text on --warning-bg
   --warning-bg: rgb(67 20 7);
   --warning-bg-soft: rgb(78 35 9);
   --warning-border: rgb(234 88 12);
   --warning-border-strong: rgb(217 119 6);
 
-  --caution-fg: rgb(252 211 77);
-  --caution-fg-strong: rgb(252 211 77);
+  --caution-fg: rgb(252 211 77); // yellow-300 — text on --caution-bg
+  --caution-fg-strong: rgb(254 240 138); // yellow-200 — emphasized text on --caution-bg
   --caution-bg: rgb(66 32 6);
   --caution-border: rgb(202 138 4);
   --caution-border-soft: rgb(180 130 20);

--- a/apps/draft-assistant/frontend/src/styles.scss
+++ b/apps/draft-assistant/frontend/src/styles.scss
@@ -105,6 +105,7 @@ strong {
 :root {
   --primary: #4c22bd;
   --primary-container: #6442d6;
+  --primary-on-active: var(--primary);
   --surface: #fdf8fb;
   --surface-container-low: #f7f2f5;
   --surface-container-lowest: #ffffff;
@@ -112,6 +113,75 @@ strong {
   --surface-container-highest: #e6e1e4;
   --on-surface: #1c1b1d;
   --outline-variant: #4c22bd26; // 15% opacity
+
+  // ── Neutral text scale (slate palette) ───────────────────────────────────
+  --text-strong: rgb(15 23 42); // slate-900
+  --text-heading: rgb(30 41 59); // slate-800
+  --text-secondary: rgb(51 65 85); // slate-700
+  --text-muted: rgb(71 85 105); // slate-600
+  --text-faint: rgb(100 116 139); // slate-500
+  --text-disabled: rgb(148 163 184); // slate-400
+
+  // ── Neutral borders & background tints ──────────────────────────────────
+  --border-default: rgb(203 213 225); // slate-300
+  --border-subtle: rgb(226 232 240); // slate-200
+  --surface-muted: rgb(241 245 249); // slate-100
+
+  // ── Semantic: success (green) ────────────────────────────────────────────
+  --success: rgb(22 163 74);
+  --success-strong: rgb(22 101 52);
+  --success-soft-bg: rgb(220 252 231);
+  --success-bold-bg: rgb(187 247 208);
+  --success-border: rgb(74 222 128);
+
+  // ── Semantic: danger (red) ───────────────────────────────────────────────
+  --danger: rgb(220 38 38);
+  --danger-strong: rgb(185 28 28);
+  --danger-fg: rgb(153 27 27);
+  --danger-bg: rgb(254 226 226);
+  --danger-border: rgb(239 68 68);
+
+  // ── Semantic: warning (orange) ───────────────────────────────────────────
+  --warning: rgb(217 119 6);
+  --warning-fg: rgb(154 52 18);
+  --warning-fg-strong: rgb(120 53 15);
+  --warning-bg: rgb(255 237 213);
+  --warning-bg-soft: rgb(254 243 199);
+  --warning-border: rgb(251 146 60);
+  --warning-border-strong: rgb(251 191 36);
+
+  // ── Semantic: caution (yellow) ───────────────────────────────────────────
+  --caution-fg: rgb(113 63 18);
+  --caution-fg-strong: rgb(133 77 14);
+  --caution-bg: rgb(254 249 195);
+  --caution-border: rgb(234 179 8);
+  --caution-border-soft: rgb(252 211 77);
+
+  // ── Semantic: info (blue) ────────────────────────────────────────────────
+  --info: rgb(29 78 216);
+  --info-strong: rgb(30 64 175);
+  --info-fg: rgb(29 78 216);
+  --info-bg: rgb(219 234 254);
+  --info-bg-soft: rgb(239 246 255);
+  --info-border: rgb(59 130 246);
+  --info-border-strong: rgb(37 99 235);
+
+  // ── Position colors (solid + tinted bg/fg pairs) ────────────────────────
+  --pos-qb: rgb(239 68 68);
+  --pos-rb: rgb(34 197 94);
+  --pos-wr: rgb(59 130 246);
+  --pos-te: rgb(249 115 22);
+  --pos-qb-bg: rgb(254 226 226);
+  --pos-qb-fg: rgb(185 28 28);
+  --pos-rb-bg: rgb(220 252 231);
+  --pos-rb-fg: rgb(22 101 52);
+  --pos-wr-bg: rgb(219 234 254);
+  --pos-wr-fg: rgb(29 78 216);
+  --pos-te-bg: rgb(255 237 213);
+  --pos-te-fg: rgb(154 52 18);
+
+  // ── Misc accents ─────────────────────────────────────────────────────────
+  --star-active: rgb(202 138 4);
 }
 
 // ── Dark-mode CSS variable overrides ─────────────────────────────────────────
@@ -123,6 +193,64 @@ html.dark {
   --surface-container-highest: #36343b;
   --on-surface: #e6e0e9;
   --outline-variant: #b0acbc40; // 25% opacity
+
+  --primary-on-active: #c4b5fd;
+
+  --text-strong: rgb(226 232 240);
+  --text-heading: rgb(226 232 240);
+  --text-secondary: rgb(203 213 225);
+  --text-muted: rgb(148 163 184);
+  --text-faint: rgb(100 116 139);
+  --text-disabled: rgb(71 85 105);
+
+  --border-default: rgb(75 85 99);
+  --border-subtle: rgb(51 65 85);
+  --surface-muted: rgb(30 41 59);
+
+  --success: rgb(74 222 128);
+  --success-strong: rgb(110 231 183);
+  --success-soft-bg: rgb(20 83 45);
+  --success-bold-bg: rgb(6 78 59);
+  --success-border: rgb(34 197 94);
+
+  --danger: rgb(252 165 165);
+  --danger-strong: rgb(252 165 165);
+  --danger-fg: rgb(252 165 165);
+  --danger-bg: rgb(127 29 29);
+  --danger-border: rgb(220 38 38);
+
+  --warning: rgb(251 191 36);
+  --warning-fg: rgb(253 186 116);
+  --warning-fg-strong: rgb(253 186 116);
+  --warning-bg: rgb(67 20 7);
+  --warning-bg-soft: rgb(78 35 9);
+  --warning-border: rgb(234 88 12);
+  --warning-border-strong: rgb(217 119 6);
+
+  --caution-fg: rgb(252 211 77);
+  --caution-fg-strong: rgb(252 211 77);
+  --caution-bg: rgb(66 32 6);
+  --caution-border: rgb(202 138 4);
+  --caution-border-soft: rgb(180 130 20);
+
+  --info: rgb(147 197 253);
+  --info-strong: rgb(147 197 253);
+  --info-fg: rgb(147 197 253);
+  --info-bg: rgb(30 58 138);
+  --info-bg-soft: rgb(23 37 84);
+  --info-border: rgb(59 130 246);
+  --info-border-strong: rgb(59 130 246);
+
+  --pos-qb-bg: rgb(127 29 29);
+  --pos-qb-fg: rgb(252 165 165);
+  --pos-rb-bg: rgb(20 83 45);
+  --pos-rb-fg: rgb(134 239 172);
+  --pos-wr-bg: rgb(30 58 138);
+  --pos-wr-fg: rgb(147 197 253);
+  --pos-te-bg: rgb(67 20 7);
+  --pos-te-fg: rgb(253 186 116);
+
+  --star-active: rgb(252 211 77);
 
   body {
     background: var(--surface);


### PR DESCRIPTION
## Summary

- Adds a comprehensive set of semantic CSS variables to `styles.scss` (`--text-*`, `--border-*`, `--surface-muted`, `--success-*`, `--danger-*`, `--warning-*`, `--caution-*`, `--info-*`, `--pos-*-bg/fg`, `--star-active`, `--primary-on-active`) that swap automatically between light and dark mode.
- Sweeps through 24 component / partial SCSS files and replaces literal slate / red / green / blue / orange `rgb()` and `#hex` values with the new tokens.
- Removes most `html.dark { ... }` overrides — they are no longer needed because the variables themselves carry the dark-mode values.

Net diff: **+475 / −1073** (much shorter SCSS, single source of truth for color).

## What is intentionally kept literal

- Per-tier palette in `_tier-colors.scss` (each tier has bespoke red/orange/yellow/green/teal/blue/indigo/violet hues that are part of the design).
- Pure-black drop-shadows and modal backdrop overlays (`rgb(0 0 0 / 0.x)`) — these look correct in both modes.

## Test plan

- [x] `pnpm --filter @ff/draft-assistant-frontend build:ci` succeeds.
- [ ] Visual check: light mode looks unchanged.
- [ ] Visual check: dark mode looks unchanged (most surfaces, badges, semantic states).
- [ ] Verify position colors, tier rows, WCS / efficiency / injury / availability / ADP-delta badges still render correctly in both modes.
- [ ] Spot-check the draft board (current pick glow, my-empty-pick outline, traded-pick orange) in both modes.

https://claude.ai/code/session_01XvKZ86AsWt34mNGSkSUQXi

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvKZ86AsWt34mNGSkSUQXi)_