### PR TITLE
Add "Free agents only" toggle to players page

### DIFF
--- a/apps/draft-assistant/frontend/src/app/features/players/players-display.util.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/features/players/players-display.util.spec.ts
@@ -33,6 +33,8 @@ function run(
   rows: PlayerRow[],
   selectedPositions: PositionFilter[] = ["QB", "RB", "WR", "TE"],
   rookiesOnly = false,
+  freeAgentsOnly = false,
+  assignedPlayerIds: string[] = [],
   sortBy: SortBy = "default",
   sortDirection: SortDirection = "asc",
   valueSource: ValueSource = "ktcValue",
@@ -42,6 +44,8 @@ function run(
     rows,
     selectedPositions,
     rookiesOnly,
+    freeAgentsOnly,
+    assignedPlayerIds,
     sortBy,
     sortDirection,
     valueSource,
@@ -78,7 +82,7 @@ describe("players-display.util", () => {
       buildRow({ playerId: "fallback", averageRank: null, ktcRank: 4 }),
     ];
 
-    const displayed = run(rows, ["QB", "RB", "WR", "TE"], false, "default", "asc", "averageRank");
+    const displayed = run(rows, ["QB", "RB", "WR", "TE"], false, false, [], "default", "asc", "averageRank");
     expect(displayed.map((row) => row.playerId)).toEqual(["avg", "fallback"]);
   });
 
@@ -89,7 +93,7 @@ describe("players-display.util", () => {
       buildRow({ playerId: "chi", team: "CHI" }),
     ];
 
-    const displayed = run(rows, ["QB", "RB", "WR", "TE"], false, "team", "asc", "ktcValue");
+    const displayed = run(rows, ["QB", "RB", "WR", "TE"], false, false, [], "team", "asc", "ktcValue");
     expect(displayed.map((row) => row.playerId)).toEqual(["atl", "chi", "null-team"]);
   });
 
@@ -99,7 +103,27 @@ describe("players-display.util", () => {
       buildRow({ playerId: "low", ktcValue: 1000 }),
     ];
 
-    const displayed = run(rows, ["QB", "RB", "WR", "TE"], false, "ktcValue", "desc", "ktcValue");
+    const displayed = run(rows, ["QB", "RB", "WR", "TE"], false, false, [], "ktcValue", "desc", "ktcValue");
     expect(displayed.map((row) => row.playerId)).toEqual(["high", "low"]);
+  });
+
+  it("hides rostered players when freeAgentsOnly is true", () => {
+    const rows = [
+      buildRow({ playerId: "rostered", fullName: "Rostered Player" }),
+      buildRow({ playerId: "free", fullName: "Free Agent" }),
+    ];
+
+    const displayed = run(rows, ["QB", "RB", "WR", "TE"], false, true, ["rostered"]);
+    expect(displayed.map((row) => row.playerId)).toEqual(["free"]);
+  });
+
+  it("shows all players when freeAgentsOnly is false regardless of assignedPlayerIds", () => {
+    const rows = [
+      buildRow({ playerId: "rostered" }),
+      buildRow({ playerId: "free" }),
+    ];
+
+    const displayed = run(rows, ["QB", "RB", "WR", "TE"], false, false, ["rostered"]);
+    expect(displayed.map((row) => row.playerId)).toEqual(["rostered", "free"]);
   });
 });

--- a/apps/draft-assistant/frontend/src/app/features/players/players-display.util.ts
+++ b/apps/draft-assistant/frontend/src/app/features/players/players-display.util.ts
@@ -24,17 +24,21 @@ export function filterAndSortPlayerRows(
   rows: PlayerRow[],
   selectedPositions: PositionFilter[],
   rookiesOnly: boolean,
+  freeAgentsOnly: boolean,
+  assignedPlayerIds: string[],
   sortBy: SortBy,
   sortDirection: SortDirection,
   valueSource: ValueSource,
   searchQuery: string,
 ): PlayerRow[] {
   const selected = new Set(selectedPositions);
+  const assignedSet = freeAgentsOnly ? new Set(assignedPlayerIds) : null;
   const normalizedQuery = searchQuery.toLowerCase().trim();
   const filtered = rows.filter((row) => {
     if (normalizedQuery && !row.fullName.toLowerCase().includes(normalizedQuery)) return false;
     if (!selected.has(row.position)) return false;
     if (rookiesOnly && !row.rookie) return false;
+    if (assignedSet && assignedSet.has(row.playerId)) return false;
     return true;
   });
 

--- a/apps/draft-assistant/frontend/src/app/features/players/players.component.html
+++ b/apps/draft-assistant/frontend/src/app/features/players/players.component.html
@@ -24,6 +24,14 @@
         Rookies only
       </mat-slide-toggle>
 
+      <mat-slide-toggle
+        [ngModel]="store.freeAgentsOnly()"
+        (ngModelChange)="store.setFreeAgentsOnly($event)"
+        [disabled]="!hasLeague()"
+      >
+        Free agents only
+      </mat-slide-toggle>
+
       <mat-form-field appearance="outline">
         <mat-label>Sort by</mat-label>
         <mat-select [ngModel]="store.sortBy()" (ngModelChange)="store.setSortBy($event)">

--- a/apps/draft-assistant/frontend/src/app/features/players/players.component.ts
+++ b/apps/draft-assistant/frontend/src/app/features/players/players.component.ts
@@ -37,6 +37,7 @@ import { PlayerCardComponent } from "../../shared/components/player-card";
 interface PlayersStoreView {
   selectedPositions: () => PositionFilter[];
   rookiesOnly: () => boolean;
+  freeAgentsOnly: () => boolean;
   searchQuery: () => string;
   sortBy: () => SortBy;
   sortDirection: () => SortDirection;
@@ -49,6 +50,7 @@ interface PlayersStoreView {
   error: () => string | null;
   displayedRows: () => PlayerRow[];
   setRookiesOnly: (value: boolean) => void;
+  setFreeAgentsOnly: (value: boolean) => void;
   setSearchQuery: (query: string) => void;
   setSortBy: (value: SortBy) => void;
   setSortDirection: (value: SortDirection) => void;
@@ -98,6 +100,8 @@ export class PlayersComponent {
   ];
   protected expandedPlayerId: string | null = null;
   protected readonly positions = ["QB", "RB", "WR", "TE"] as const;
+
+  protected readonly hasLeague = computed(() => !!this.appStore.selectedLeague());
 
   private readonly seasonYear = computed(() => {
     const season = this.appStore.selectedLeague()?.season;

--- a/apps/draft-assistant/frontend/src/app/features/players/players.store.ts
+++ b/apps/draft-assistant/frontend/src/app/features/players/players.store.ts
@@ -9,6 +9,7 @@ import {
 } from "@ngrx/signals";
 import { firstValueFrom } from "rxjs";
 import { KtcRatingService } from "../../core/adapters/ktc/ktc-rating.service";
+import { SleeperService } from "../../core/adapters/sleeper/sleeper.service";
 import { TierSource } from "../../core/models";
 import { AppStore } from "../../core/state/app.store";
 import { PlayerNormalizationService } from "../../core/services/player-normalization.service";
@@ -33,6 +34,8 @@ interface PlayersState {
   rows: PlayerRow[];
   selectedPositions: PositionFilter[];
   rookiesOnly: boolean;
+  freeAgentsOnly: boolean;
+  assignedPlayerIds: string[];
   searchQuery: string;
   sortBy: SortBy;
   sortDirection: SortDirection;
@@ -51,6 +54,8 @@ export const PlayersStore = signalStore(
     rows: [],
     selectedPositions: DEFAULT_POSITIONS,
     rookiesOnly: false,
+    freeAgentsOnly: false,
+    assignedPlayerIds: [],
     searchQuery: "",
     sortBy: "default",
     sortDirection: "asc",
@@ -64,6 +69,8 @@ export const PlayersStore = signalStore(
         store.rows(),
         store.selectedPositions(),
         store.rookiesOnly(),
+        store.freeAgentsOnly(),
+        store.assignedPlayerIds(),
         store.sortBy(),
         store.sortDirection(),
         store.valueSource(),
@@ -83,6 +90,7 @@ export const PlayersStore = signalStore(
       appStore = inject(AppStore),
       ktcService = inject(KtcRatingService),
       playerNorm = inject(PlayerNormalizationService),
+      sleeperService = inject(SleeperService),
     ) => {
       return {
         async loadPlayers(): Promise<void> {
@@ -93,7 +101,11 @@ export const PlayersStore = signalStore(
             const isSuperflex = (selectedLeague?.roster_positions ?? []).includes("SUPER_FLEX");
             const currentSeason = Number(selectedLeague?.season ?? new Date().getFullYear());
 
-            const [rows, ktcPlayers, metadata] = await Promise.all([
+            const rostersPromise = selectedLeague
+              ? firstValueFrom(sleeperService.getLeagueRosters(selectedLeague.league_id))
+              : Promise.resolve([]);
+
+            const [rows, ktcPlayers, metadata, rosters] = await Promise.all([
               playerNorm.buildPlayerRows({
                 format: { isSuperflex, isRookie: false },
                 season: currentSeason,
@@ -101,10 +113,14 @@ export const PlayersStore = signalStore(
               }),
               firstValueFrom(ktcService.fetchPlayers(isSuperflex)),
               firstValueFrom(ktcService.fetchMetadata()),
+              rostersPromise,
             ]);
+
+            const assignedPlayerIds = rosters.flatMap((r) => r.players ?? []);
 
             patchState(store, {
               rows,
+              assignedPlayerIds,
               loading: false,
               ktcUnavailable: ktcPlayers.length === 0,
               ktcSyncedAt: metadata?.generatedAt ?? null,
@@ -123,6 +139,9 @@ export const PlayersStore = signalStore(
         },
         setRookiesOnly(rookiesOnly: boolean): void {
           patchState(store, { rookiesOnly });
+        },
+        setFreeAgentsOnly(freeAgentsOnly: boolean): void {
+          patchState(store, { freeAgentsOnly });
         },
         setSortBy(sortBy: SortBy): void {
           patchState(store, { sortBy });

--- a/apps/draft-assistant/frontend/src/app/features/players/players.store.ts
+++ b/apps/draft-assistant/frontend/src/app/features/players/players.store.ts
@@ -102,7 +102,7 @@ export const PlayersStore = signalStore(
             const currentSeason = Number(selectedLeague?.season ?? new Date().getFullYear());
 
             const rostersPromise = selectedLeague
-              ? firstValueFrom(sleeperService.getLeagueRosters(selectedLeague.league_id))
+              ? firstValueFrom(sleeperService.getLeagueRosters(selectedLeague.league_id)).catch(() => [])
               : Promise.resolve([]);
 
             const [rows, ktcPlayers, metadata, rosters] = await Promise.all([


### PR DESCRIPTION
## Summary

- Adds a **Free agents only** slide toggle to the players page controls, placed alongside the existing "Rookies only" toggle
- On load, fetches the selected league's rosters from the Sleeper API and stores the full set of rostered player IDs
- When enabled, filters out any player already on a roster in the current league — leaving only true free agents
- Toggle is disabled (greyed out) when no league is selected

## Test plan

- [ ] Select a Sleeper league on the home page, navigate to `/players`
- [ ] Enable **Free agents only** — list should shrink; verify no remaining player appears on any team roster in that league
- [ ] Disable the toggle — full list returns
- [ ] Without a league selected, confirm the toggle is disabled
- [ ] Confirm position filters, rookies-only, and search work correctly alongside the new toggle

https://claude.ai/code/session_01Ge5KQQUaTdmazM3N98NHzk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ge5KQQUaTdmazM3N98NHzk)_