### PR TITLE
Make WCS default sort and Flock default tier/value filter

### DIFF
--- a/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
+++ b/apps/draft-assistant/frontend/src/app/features/draft/draft.store.ts
@@ -223,9 +223,9 @@ export const DraftStore = signalStore(
     rookiesOnly: false,
     starredPlayerIds: [],
     lastUpdatedAt: null,
-    tierSource: "ktc",
-    valueSource: "ktcValue",
-    sortSource: "combinedTier" as DraftSortSource,
+    tierSource: "flock",
+    valueSource: "averageRank",
+    sortSource: "weightedComposite" as DraftSortSource,
     searchQuery: "",
     neededPositionsOnly: false,
     tierDropAlerts: [],
@@ -1384,7 +1384,7 @@ export const DraftStore = signalStore(
       };
 
       const loadSortSource = (leagueId: string | null): DraftSortSource => {
-        if (!leagueId) return "combinedTier";
+        if (!leagueId) return "weightedComposite";
         const saved = storage.getRawItem(sortSourceStorageKey(leagueId));
         const valid: DraftSortSource[] = [
           "combinedTier",
@@ -1399,7 +1399,7 @@ export const DraftStore = signalStore(
         ];
         return valid.includes(saved as DraftSortSource)
           ? (saved as DraftSortSource)
-          : "combinedTier";
+          : "weightedComposite";
       };
 
       const loadSavedPositions = (leagueId: string | null): DraftPositionFilter[] => {

--- a/apps/draft-assistant/frontend/src/app/features/players/players-display.util.spec.ts
+++ b/apps/draft-assistant/frontend/src/app/features/players/players-display.util.spec.ts
@@ -82,7 +82,16 @@ describe("players-display.util", () => {
       buildRow({ playerId: "fallback", averageRank: null, ktcRank: 4 }),
     ];
 
-    const displayed = run(rows, ["QB", "RB", "WR", "TE"], false, false, [], "default", "asc", "averageRank");
+    const displayed = run(
+      rows,
+      ["QB", "RB", "WR", "TE"],
+      false,
+      false,
+      [],
+      "default",
+      "asc",
+      "averageRank",
+    );
     expect(displayed.map((row) => row.playerId)).toEqual(["avg", "fallback"]);
   });
 
@@ -93,7 +102,16 @@ describe("players-display.util", () => {
       buildRow({ playerId: "chi", team: "CHI" }),
     ];
 
-    const displayed = run(rows, ["QB", "RB", "WR", "TE"], false, false, [], "team", "asc", "ktcValue");
+    const displayed = run(
+      rows,
+      ["QB", "RB", "WR", "TE"],
+      false,
+      false,
+      [],
+      "team",
+      "asc",
+      "ktcValue",
+    );
     expect(displayed.map((row) => row.playerId)).toEqual(["atl", "chi", "null-team"]);
   });
 
@@ -103,7 +121,16 @@ describe("players-display.util", () => {
       buildRow({ playerId: "low", ktcValue: 1000 }),
     ];
 
-    const displayed = run(rows, ["QB", "RB", "WR", "TE"], false, false, [], "ktcValue", "desc", "ktcValue");
+    const displayed = run(
+      rows,
+      ["QB", "RB", "WR", "TE"],
+      false,
+      false,
+      [],
+      "ktcValue",
+      "desc",
+      "ktcValue",
+    );
     expect(displayed.map((row) => row.playerId)).toEqual(["high", "low"]);
   });
 
@@ -118,10 +145,7 @@ describe("players-display.util", () => {
   });
 
   it("shows all players when freeAgentsOnly is false regardless of assignedPlayerIds", () => {
-    const rows = [
-      buildRow({ playerId: "rostered" }),
-      buildRow({ playerId: "free" }),
-    ];
+    const rows = [buildRow({ playerId: "rostered" }), buildRow({ playerId: "free" })];
 
     const displayed = run(rows, ["QB", "RB", "WR", "TE"], false, false, ["rostered"]);
     expect(displayed.map((row) => row.playerId)).toEqual(["rostered", "free"]);

--- a/apps/draft-assistant/frontend/src/app/features/players/players-display.util.ts
+++ b/apps/draft-assistant/frontend/src/app/features/players/players-display.util.ts
@@ -1,5 +1,5 @@
 export type PositionFilter = "QB" | "RB" | "WR" | "TE";
-export type SortBy = "default" | "name" | "position" | "age" | "ktcValue" | "team";
+export type SortBy = "default" | "name" | "position" | "age" | "ktcValue" | "team" | "weightedComposite";
 export type SortDirection = "asc" | "desc";
 export type ValueSource = "ktcValue" | "averageRank";
 
@@ -18,6 +18,7 @@ export interface PlayerRow {
   flockAverageTier: number | null;
   flockAveragePositionalTier: number | null;
   sleeperRank: number;
+  baseValue: number | null;
 }
 
 export function filterAndSortPlayerRows(
@@ -74,6 +75,12 @@ export function filterAndSortPlayerRows(
       const aValue = (valueSource === "ktcValue" ? a.ktcValue : a.averageRank) ?? -1;
       const bValue = (valueSource === "ktcValue" ? b.ktcValue : b.averageRank) ?? -1;
       return (aValue - bValue) * dir;
+    }
+
+    if (sortBy === "weightedComposite") {
+      const aScore = a.baseValue ?? -1;
+      const bScore = b.baseValue ?? -1;
+      return (bScore - aScore) * dir;
     }
 
     const aTeam = a.team ?? "ZZZ";

--- a/apps/draft-assistant/frontend/src/app/features/players/players-display.util.ts
+++ b/apps/draft-assistant/frontend/src/app/features/players/players-display.util.ts
@@ -1,5 +1,12 @@
 export type PositionFilter = "QB" | "RB" | "WR" | "TE";
-export type SortBy = "default" | "name" | "position" | "age" | "ktcValue" | "team" | "weightedComposite";
+export type SortBy =
+  | "default"
+  | "name"
+  | "position"
+  | "age"
+  | "ktcValue"
+  | "team"
+  | "weightedComposite";
 export type SortDirection = "asc" | "desc";
 export type ValueSource = "ktcValue" | "averageRank";
 
@@ -18,7 +25,7 @@ export interface PlayerRow {
   flockAverageTier: number | null;
   flockAveragePositionalTier: number | null;
   sleeperRank: number;
-  baseValue: number | null;
+  baseValue?: number | null;
 }
 
 export function filterAndSortPlayerRows(
@@ -78,9 +85,9 @@ export function filterAndSortPlayerRows(
     }
 
     if (sortBy === "weightedComposite") {
-      const aScore = a.baseValue ?? -1;
-      const bScore = b.baseValue ?? -1;
-      return (bScore - aScore) * dir;
+      const aScore = a.baseValue ?? -Infinity;
+      const bScore = b.baseValue ?? -Infinity;
+      return (aScore - bScore) * dir;
     }
 
     const aTeam = a.team ?? "ZZZ";

--- a/apps/draft-assistant/frontend/src/app/features/players/players.component.html
+++ b/apps/draft-assistant/frontend/src/app/features/players/players.component.html
@@ -35,6 +35,7 @@
       <mat-form-field appearance="outline">
         <mat-label>Sort by</mat-label>
         <mat-select [ngModel]="store.sortBy()" (ngModelChange)="store.setSortBy($event)">
+          <mat-option value="weightedComposite">Weighted Composite (WCS)</mat-option>
           <mat-option value="default">Rank (default)</mat-option>
           <mat-option value="ktcValue">Value</mat-option>
           <mat-option value="name">Name</mat-option>

--- a/apps/draft-assistant/frontend/src/app/features/players/players.store.ts
+++ b/apps/draft-assistant/frontend/src/app/features/players/players.store.ts
@@ -62,7 +62,7 @@ export const PlayersStore = signalStore(
     assignedPlayerIds: [],
     searchQuery: "",
     sortBy: "weightedComposite",
-    sortDirection: "asc",
+    sortDirection: "desc",
     tierSource: "flock",
     valueSource: "averageRank",
   }),
@@ -107,7 +107,9 @@ export const PlayersStore = signalStore(
             const currentSeason = Number(selectedLeague?.season ?? new Date().getFullYear());
 
             const rostersPromise = selectedLeague
-              ? firstValueFrom(sleeperService.getLeagueRosters(selectedLeague.league_id)).catch(() => [])
+              ? firstValueFrom(sleeperService.getLeagueRosters(selectedLeague.league_id)).catch(
+                  () => [],
+                )
               : Promise.resolve([]);
 
             const [rows, ktcPlayers, metadata, rosters] = await Promise.all([

--- a/apps/draft-assistant/frontend/src/app/features/players/players.store.ts
+++ b/apps/draft-assistant/frontend/src/app/features/players/players.store.ts
@@ -13,6 +13,10 @@ import { SleeperService } from "../../core/adapters/sleeper/sleeper.service";
 import { TierSource } from "../../core/models";
 import { AppStore } from "../../core/state/app.store";
 import { PlayerNormalizationService } from "../../core/services/player-normalization.service";
+import {
+  ConsensusAggregatorService,
+  ConsensusInput,
+} from "../../core/services/consensus-aggregator.service";
 import { toErrorMessage } from "../../core/utils/error.util";
 import { togglePositionFilter } from "../../core/utils/position-filter.util";
 import {
@@ -57,10 +61,10 @@ export const PlayersStore = signalStore(
     freeAgentsOnly: false,
     assignedPlayerIds: [],
     searchQuery: "",
-    sortBy: "default",
+    sortBy: "weightedComposite",
     sortDirection: "asc",
-    tierSource: "average",
-    valueSource: "ktcValue",
+    tierSource: "flock",
+    valueSource: "averageRank",
   }),
   withComputed((store) => ({
     hasRows: computed(() => store.rows().length > 0),
@@ -91,6 +95,7 @@ export const PlayersStore = signalStore(
       ktcService = inject(KtcRatingService),
       playerNorm = inject(PlayerNormalizationService),
       sleeperService = inject(SleeperService),
+      aggregator = inject(ConsensusAggregatorService),
     ) => {
       return {
         async loadPlayers(): Promise<void> {
@@ -118,8 +123,22 @@ export const PlayersStore = signalStore(
 
             const assignedPlayerIds = rosters.flatMap((r) => r.players ?? []);
 
+            const inputs: ConsensusInput[] = rows.map((row) => ({
+              playerId: row.playerId,
+              position: row.position,
+              sources: [
+                ...(row.ktcRank != null ? [{ source: "ktc", rank: row.ktcRank }] : []),
+                ...(row.averageRank != null ? [{ source: "flock", rank: row.averageRank }] : []),
+              ],
+            }));
+            const consensus = aggregator.aggregate(inputs, { weights: { ktc: 1, flock: 1 } });
+            const enrichedRows: PlayerRow[] = rows.map((row) => ({
+              ...row,
+              baseValue: consensus.get(row.playerId)?.baseValue ?? null,
+            }));
+
             patchState(store, {
-              rows,
+              rows: enrichedRows,
               assignedPlayerIds,
               loading: false,
               ktcUnavailable: ktcPlayers.length === 0,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Draft board**: default sort changed to Weighted Composite (WCS), tier source to Flock, value source to Flock Average Rank; `loadSortSource()` fallbacks updated to match so new sessions without saved preferences land on WCS
- **Players page**: same Flock tier/value defaults; adds WCS as a sort option by computing `baseValue` via `ConsensusAggregatorService` (using `ktcRank` + `averageRank` sources) after rows load, and defaults `sortBy` to `weightedComposite`

## Files changed

| File | Change |
|------|--------|
| `draft.store.ts` | Initial state + `loadSortSource()` fallbacks → WCS / Flock |
| `players-display.util.ts` | Add `baseValue` to `PlayerRow`; add `"weightedComposite"` to `SortBy`; add sort case |
| `players.store.ts` | Inject `ConsensusAggregatorService`, enrich rows with `baseValue` post-load, update defaults |
| `players.component.html` | Add "Weighted Composite (WCS)" option to sort dropdown |

## Test plan

- [ ] Open app in incognito (no saved prefs): draft board shows WCS selected, Flock tier, Flock Average Rank value
- [ ] Players page shows "Weighted Composite (WCS)" selected in sort dropdown and Flock defaults
- [ ] WCS ordering on players page looks sensible (elite QBs/RBs near top)
- [ ] Changing sort in draft, reloading: saved preference is respected
- [ ] `nx test draft-assistant` passes

https://claude.ai/code/session_01KcpuT6hcEPx2pvDJzU4sUh
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcpuT6hcEPx2pvDJzU4sUh)_